### PR TITLE
Chapter 3

### DIFF
--- a/lib/ecc/constants.rb
+++ b/lib/ecc/constants.rb
@@ -1,0 +1,9 @@
+module ECC
+  # parameters for curve secp256k1 used for Bitcoin
+  A = 0
+  B = 7
+  P = 2**256 - 2**32 - 977
+  G_X = 0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
+  G_Y = 0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8
+  N = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
+end

--- a/lib/ecc/field_element.rb
+++ b/lib/ecc/field_element.rb
@@ -40,10 +40,15 @@ module ECC
     end
 
     def *(other)
-      check_prime_for('multiply', other)
+      if other.is_a?(FieldElement)
+        check_prime_for('multiply', other)
 
-      num = (@num * other.num) % @prime
-      self.class.new(num, @prime)
+        num = (@num * other.num) % @prime
+        self.class.new(num, @prime)
+      else
+        num = (@num * other) % @prime
+        self.class.new(num, @prime)
+      end
     end
 
     def **(exponent)
@@ -60,6 +65,10 @@ module ECC
     end
 
     private
+
+    def coerce(something)
+      [self, something]
+    end
 
     def check_prime_for(operation, other)
       if @prime != other.prime

--- a/lib/ecc/point.rb
+++ b/lib/ecc/point.rb
@@ -47,46 +47,31 @@ module ECC
       current = self
       result = identity
       while coef != 0
-        if coef & 1 == 1
-          result += current
-        end
+        result += current if coef & 1 == 1
         current += current
         coef >>= 1
       end
-      return result
+      result
     end
 
     private
 
+    def coerce(something)
+      [self, something]
+    end
+
     def add_different_points(other)
-      slope = (other.y - @y) / (other.x - @x)
+      slope = @x.respond_to?(:to_f) ? (other.y - @y).to_f / (other.x - @x) :
+                                      (other.y - @y) / (other.x - @x)
       x = slope**2 - @x - other.x
       y = slope * (@x - x) - @y
       self.class.new(x, y, @a, @b)
     end
 
     def add_same_points
-     if @x.is_a?(Integer)
-      add_same_points_integer
-     else
-      add_same_points_field
-     end
-    end
-
-    def add_same_points_field
-      if (@y == ECC::FieldElement.new(0, @y.prime) )
-        return identity
-      end
-
-      slope = (ECC::FieldElement.new(3, @x.prime) * @x ** 2 + @a) / (ECC::FieldElement.new(2, @y.prime) * @y)
-      x = slope ** 2 - ECC::FieldElement.new(2, @x.prime) * @x
-      y = slope * (@x - x) - @y
-      self.class.new(x, y, @a, @b)
-    end
-
-    def add_same_points_integer
-      return identity if @y == 0
-      slope = (3 * @x ** 2 + @a).to_f / (2 * @y)
+      return identity if @y == 0 * self.x
+      slope = @x.respond_to?(:to_f) ? ((3 * @x ** 2 + @a).to_f / (2 * @y)) :
+                                      ((3 * @x ** 2 + @a) / (2 * @y))
       x = slope ** 2 - 2 * @x
       y = slope * (@x - x) - @y
       self.class.new(x, y, @a, @b)

--- a/lib/ecc/point.rb
+++ b/lib/ecc/point.rb
@@ -1,3 +1,5 @@
+require_relative 'field_element.rb'
+
 module ECC
   class Point
     attr_reader :x, :y, :a, :b
@@ -17,13 +19,17 @@ module ECC
     def ==(other)
       return false unless other
 
-      @a == other.a && @b == other.b && @x == other.x && @y == other.y 
+      @a == other.a && @b == other.b && @x == other.x && @y == other.y
     end
 
     def to_s
       return "Point(infinity)_#{@a}_#{@b}" if @x.nil? && @y.nil?
 
-      "Point(#{@x}, #{@y})_#{@a}_#{@b}"
+      if @x.is_a?(Integer)
+        "Point(#{@x}, #{@y})_#{@a}_#{@b}"
+      else
+        "Point(#{@x.num}, #{@y.num})_#{@a.num}_#{@b.num} FieldElement(#{@x.prime})"
+      end
     end
 
     def +(other)
@@ -37,16 +43,48 @@ module ECC
       self != other ? add_different_points(other) : add_same_points
     end
 
+    def *(coef)
+      current = self
+      result = identity
+      while coef != 0
+        if coef & 1 == 1
+          result += current
+        end
+        current += current
+        coef >>= 1
+      end
+      return result
+    end
+
     private
 
     def add_different_points(other)
-      slope = (other.y - @y).to_f/(other.x - @x)
+      slope = (other.y - @y) / (other.x - @x)
       x = slope**2 - @x - other.x
       y = slope * (@x - x) - @y
       self.class.new(x, y, @a, @b)
     end
 
     def add_same_points
+     if @x.is_a?(Integer)
+      add_same_points_integer
+     else
+      add_same_points_field
+     end
+    end
+
+    def add_same_points_field
+      if (@y == ECC::FieldElement.new(0, @y.prime) )
+        return identity
+      end
+
+      slope = (ECC::FieldElement.new(3, @x.prime) * @x ** 2 + @a) / (ECC::FieldElement.new(2, @y.prime) * @y)
+      x = slope ** 2 - ECC::FieldElement.new(2, @x.prime) * @x
+      y = slope * (@x - x) - @y
+      self.class.new(x, y, @a, @b)
+    end
+
+    def add_same_points_integer
       return identity if @y == 0
       slope = (3 * @x ** 2 + @a).to_f / (2 * @y)
       x = slope ** 2 - 2 * @x

--- a/lib/ecc/private_key.rb
+++ b/lib/ecc/private_key.rb
@@ -1,0 +1,62 @@
+require_relative 's256_point.rb'
+require_relative 'signature.rb'
+require_relative 'constants.rb'
+require_relative '../helper.rb'
+require 'openssl'
+
+module ECC
+  class PrivateKey
+    attr_reader :point
+
+    def initialize(secret)
+      @secret = secret
+      @point = ECC::S256Point.G * secret
+    end
+
+    def to_s
+      @num.to_s.rjust(64, '0')
+    end
+
+    def sign(z)
+      k = deterministic_k(z)
+      r = ECC::S256Point.G.*(k).x.num
+      k_inv = k.pow(ECC::N - 2, ECC::N)
+      s = (z + r * @secret ) * k_inv % ECC::N
+
+      s = ECC::N - s if s > ECC::N / 2
+
+      return ECC::Signature.new(r, s)
+    end
+
+    def deterministic_k(z)
+      k = "\x00".b * 32
+      v = "\x01".b * 32
+      if z > ECC::N
+        z -= ECC::N
+      end
+
+      # pending: bytes has to of size 32
+      z_bytes = [z].pack("N")
+      secret_bytes = [@secret].pack("N")
+
+      message_1 = v + "\x00".b + secret_bytes + z_bytes
+      k = OpenSSL::HMAC.digest("SHA256", k, message_1)
+      v = OpenSSL::HMAC.digest("SHA256", k, v)
+
+      message_2 = v + "\x01".b + secret_bytes + z_bytes
+      k = OpenSSL::HMAC.digest("SHA256", k, message_2)
+      v = OpenSSL::HMAC.digest("SHA256", k, v)
+
+      while true
+        v = OpenSSL::HMAC.digest("SHA256", k, v)
+        candidate = v.unpack("N").first
+        if candidate >= 1 && candidate < N
+          return candidate
+        end
+
+        k = OpenSSL::HMAC.digest("SHA256", k, v + "\x00".b)
+        v = OpenSSL::HMAC.digest("SHA256", k, v)
+      end
+    end
+  end
+end

--- a/lib/ecc/private_key.rb
+++ b/lib/ecc/private_key.rb
@@ -1,6 +1,6 @@
 require_relative 's256_point.rb'
 require_relative 'signature.rb'
-require_relative 'constants.rb'
+require_relative 'secp256k1_constants.rb'
 require_relative '../helper.rb'
 require 'openssl'
 
@@ -10,7 +10,7 @@ module ECC
 
     def initialize(secret)
       @secret = secret
-      @point = ECC::S256Point.G * secret
+      @point = secret * ECC::S256Point::G
     end
 
     def to_s
@@ -19,25 +19,24 @@ module ECC
 
     def sign(z)
       k = deterministic_k(z)
-      r = ECC::S256Point.G.*(k).x.num
-      k_inv = k.pow(ECC::N - 2, ECC::N)
-      s = (z + r * @secret ) * k_inv % ECC::N
+      r = (k * ECC::S256Point::G).x.num
+      k_inv = k.pow(Secp256k1Constants::N - 2, Secp256k1Constants::N)
+      s = (z + r * @secret ) * k_inv % Secp256k1Constants::N
 
-      s = ECC::N - s if s > ECC::N / 2
+      s = Secp256k1Constants::N - s if s > Secp256k1Constants::N / 2
 
-      return ECC::Signature.new(r, s)
+      ECC::Signature.new(r, s)
     end
 
     def deterministic_k(z)
       k = "\x00".b * 32
       v = "\x01".b * 32
-      if z > ECC::N
-        z -= ECC::N
+      if z > Secp256k1Constants::N
+        z -= Secp256k1Constants::N
       end
 
-      # pending: bytes has to of size 32
-      z_bytes = [z].pack("N")
-      secret_bytes = [@secret].pack("N")
+      z_bytes = [z].pack("N").rjust(32, "\x00".b)
+      secret_bytes = [@secret].pack("N").rjust(32, "\x00".b)
 
       message_1 = v + "\x00".b + secret_bytes + z_bytes
       k = OpenSSL::HMAC.digest("SHA256", k, message_1)
@@ -50,9 +49,7 @@ module ECC
       while true
         v = OpenSSL::HMAC.digest("SHA256", k, v)
         candidate = v.unpack("N").first
-        if candidate >= 1 && candidate < N
-          return candidate
-        end
+        return candidate if candidate >= 1 && candidate < Secp256k1Constants::N
 
         k = OpenSSL::HMAC.digest("SHA256", k, v + "\x00".b)
         v = OpenSSL::HMAC.digest("SHA256", k, v)

--- a/lib/ecc/s256_field.rb
+++ b/lib/ecc/s256_field.rb
@@ -1,0 +1,15 @@
+require_relative 'field_element.rb'
+require_relative 'constants.rb'
+
+module ECC
+  class S256Field < FieldElement
+
+    def initialize(num, prime = ECC::P)
+      super(num, prime)
+    end
+
+    def to_s
+      @num.to_s.rjust(64, '0')
+    end
+  end
+end

--- a/lib/ecc/s256_field.rb
+++ b/lib/ecc/s256_field.rb
@@ -1,10 +1,10 @@
 require_relative 'field_element.rb'
-require_relative 'constants.rb'
+require_relative 'secp256k1_constants.rb'
 
 module ECC
   class S256Field < FieldElement
 
-    def initialize(num, prime = ECC::P)
+    def initialize(num, prime = Secp256k1Constants::P)
       super(num, prime)
     end
 

--- a/lib/ecc/s256_point.rb
+++ b/lib/ecc/s256_point.rb
@@ -1,0 +1,45 @@
+require_relative 's256_field.rb'
+require_relative 'point.rb'
+require_relative 'constants.rb'
+
+module ECC
+  class S256Point < Point
+
+    def initialize(x, y, a = 0, b = 7)
+      a = S256Field.new(ECC::A)
+      b = S256Field.new(ECC::B)
+
+      if x.is_a?(Integer)
+        x = S256Field.new(x)
+        y = S256Field.new(y)
+        super(x, y, a, b)
+      else
+        super(x, y, a, b)
+      end
+    end
+
+    def to_s
+      return "Point(infinity)_S256Field" if @x.nil? && @y.nil?
+
+      "Point(#{@x}, #{@y})_S256Field"
+    end
+
+    def *(coef)
+      # to add eficiency, mod by order of group N
+      coef = coef % ECC::N
+      super
+    end
+
+    def self.G
+      S256Point.new(ECC::G_X, ECC::G_Y)
+    end
+
+    def verify(z, sig)
+      s_inv = sig.s.pow(ECC::N - 2, ECC::N)
+      u = z * s_inv % ECC::N
+      v = sig.r * s_inv % ECC::N
+      total = self.class.G.*(u) + self.*(v)
+      return total.x.num == sig.r
+    end
+  end
+end

--- a/lib/ecc/s256_point.rb
+++ b/lib/ecc/s256_point.rb
@@ -35,12 +35,12 @@ module ECC
       S256Point.new(Secp256k1Constants::G_X, Secp256k1Constants::G_Y)
     end
 
-    def verify(z, sig)
-      s_inv = sig.s.pow(Secp256k1Constants::N - 2, Secp256k1Constants::N)
+    def verify(z, signature)
+      s_inv = signature.s.pow(Secp256k1Constants::N - 2, Secp256k1Constants::N)
       u = z * s_inv % Secp256k1Constants::N
-      v = sig.r * s_inv % Secp256k1Constants::N
-      total = self.class.G.*(u) + self.*(v)
-      total.x.num == sig.r
+      v = signature.r * s_inv % Secp256k1Constants::N
+      random_target = (u * self.class::G + v * self).x.num
+      random_target == signature.r
     end
   end
 end

--- a/lib/ecc/s256_point.rb
+++ b/lib/ecc/s256_point.rb
@@ -1,13 +1,13 @@
 require_relative 's256_field.rb'
 require_relative 'point.rb'
-require_relative 'constants.rb'
+require_relative 'secp256k1_constants.rb'
 
 module ECC
   class S256Point < Point
 
     def initialize(x, y, a = 0, b = 7)
-      a = S256Field.new(ECC::A)
-      b = S256Field.new(ECC::B)
+      a = S256Field.new(Secp256k1Constants::A)
+      b = S256Field.new(Secp256k1Constants::B)
 
       if x.is_a?(Integer)
         x = S256Field.new(x)
@@ -18,6 +18,8 @@ module ECC
       end
     end
 
+    G = S256Point.new(Secp256k1Constants::G_X, Secp256k1Constants::G_Y)
+
     def to_s
       return "Point(infinity)_S256Field" if @x.nil? && @y.nil?
 
@@ -25,21 +27,20 @@ module ECC
     end
 
     def *(coef)
-      # to add eficiency, mod by order of group N
-      coef = coef % ECC::N
-      super
+      coef = coef % Secp256k1Constants::N
+      super(coef)
     end
 
     def self.G
-      S256Point.new(ECC::G_X, ECC::G_Y)
+      S256Point.new(Secp256k1Constants::G_X, Secp256k1Constants::G_Y)
     end
 
     def verify(z, sig)
-      s_inv = sig.s.pow(ECC::N - 2, ECC::N)
-      u = z * s_inv % ECC::N
-      v = sig.r * s_inv % ECC::N
+      s_inv = sig.s.pow(Secp256k1Constants::N - 2, Secp256k1Constants::N)
+      u = z * s_inv % Secp256k1Constants::N
+      v = sig.r * s_inv % Secp256k1Constants::N
       total = self.class.G.*(u) + self.*(v)
-      return total.x.num == sig.r
+      total.x.num == sig.r
     end
   end
 end

--- a/lib/ecc/secp256k1_constants.rb
+++ b/lib/ecc/secp256k1_constants.rb
@@ -1,5 +1,4 @@
-module ECC
-  # parameters for curve secp256k1 used for Bitcoin
+module Secp256k1Constants
   A = 0
   B = 7
   P = 2**256 - 2**32 - 977

--- a/lib/ecc/signature.rb
+++ b/lib/ecc/signature.rb
@@ -1,0 +1,15 @@
+module ECC
+
+  class Signature
+    attr_reader :r, :s
+
+    def initialize(r, s)
+      @r = r
+      @s = s
+    end
+
+    def to_s
+      "Signature(#{@r}, #{s})"
+    end
+  end
+end

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -1,0 +1,6 @@
+require 'digest'
+
+def hash256(s)
+  first_round = Digest::SHA256.digest(s)
+  Digest::SHA256.hexdigest(first_round).to_i(16)
+end

--- a/spec/ecc/ecc_spec.rb
+++ b/spec/ecc/ecc_spec.rb
@@ -42,8 +42,12 @@ RSpec.describe ECC do
       let(:y) { ECC::FieldElement.new(71, prime) }
       let(:solution) { ECC::Point.new(x, y, a, b) }
 
-      it 'returns the point scalar product' do
+      it 'returns the point scalar product (scalar on the right side)' do
         expect(point_1 * scalar ).to eq solution
+      end
+
+      it 'returns the point scalar product (scalar on the left side)' do
+        expect(scalar * point_1 ).to eq solution
       end
   end
 end

--- a/spec/ecc/ecc_spec.rb
+++ b/spec/ecc/ecc_spec.rb
@@ -1,0 +1,49 @@
+require 'ecc/field_element'
+require 'ecc/point'
+
+RSpec.describe ECC do
+  let(:prime) { 223 }
+  let(:a) { ECC::FieldElement.new(0, prime) }
+  let(:b) { ECC::FieldElement.new(7, prime) }
+  let(:x1) { ECC::FieldElement.new(192, prime) }
+  let(:y1) { ECC::FieldElement.new(105, prime) }
+  let(:point_1) { ECC::Point.new(x1, y1, a, b) }
+
+  describe 'point init over field elements' do
+    context 'when point is not part of the curve' do
+      let(:x) { ECC::FieldElement.new(200, prime) }
+      let(:y) { ECC::FieldElement.new(199, prime) }
+
+      it 'raises an ArgumentError' do
+        expect { ECC::Point.new(x, y, a, b) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe 'point addition over finite elements' do
+    context 'when points are over same finite field' do
+      let(:x2) { ECC::FieldElement.new(17, prime) }
+      let(:y2) { ECC::FieldElement.new(56, prime) }
+      let(:point_2) { ECC::Point.new(x2, y2, a, b) }
+
+      let(:x_sol) { ECC::FieldElement.new(170, prime) }
+      let(:y_sol) { ECC::FieldElement.new(142, prime) }
+      let(:solution) { ECC::Point.new(x_sol, y_sol, a, b) }
+
+      it 'returns the point sum' do
+        expect(point_1 + point_2).to eq solution
+      end
+    end
+  end
+
+  describe 'scalar multiplication of point over finite elements' do
+      let(:scalar) { 2 }
+      let(:x) { ECC::FieldElement.new(49, prime) }
+      let(:y) { ECC::FieldElement.new(71, prime) }
+      let(:solution) { ECC::Point.new(x, y, a, b) }
+
+      it 'returns the point scalar product' do
+        expect(point_1 * scalar ).to eq solution
+      end
+  end
+end

--- a/spec/ecc/point_spec.rb
+++ b/spec/ecc/point_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe ECC::Point do
 
       context 'when y is equal to 0' do
         let(:point) { described_class.new(-1, 0, 0, 1) }
-        
+
         it 'returns identity' do
           result = point + point
           expect([result.x, result.y]).to eq [nil, nil]
@@ -163,4 +163,3 @@ RSpec.describe ECC::Point do
     end
   end
 end
-

--- a/spec/ecc/private_key_spec.rb
+++ b/spec/ecc/private_key_spec.rb
@@ -1,0 +1,16 @@
+require 'ecc/private_key'
+require 'ecc/signature'
+
+RSpec.describe ECC::PrivateKey do
+
+  describe 'sign' do
+    let(:secret) { rand(ECC::N) }
+    let(:private_key) { described_class.new(secret) }
+    let(:z) { rand(ECC::N) }
+    let(:signature) { private_key.sign(z) }
+
+    it 'generates a valid signature' do
+      expect(private_key.point.verify(z, signature)).to be true
+    end
+  end
+end

--- a/spec/ecc/private_key_spec.rb
+++ b/spec/ecc/private_key_spec.rb
@@ -9,8 +9,21 @@ RSpec.describe ECC::PrivateKey do
     let(:z) { rand(Secp256k1Constants::N) }
     let(:signature) { private_key.sign(z) }
 
-    it 'generates a valid signature' do
-      expect(private_key.point.verify(z, signature)).to be true
+    context 'validation using point method verify' do
+      it 'generates a valid signature' do
+        expect(private_key.point.verify(z, signature)).to be true
+      end
+    end
+
+    context 'validation using analytical calculations' do
+      let(:s_inv) { signature.s.pow(Secp256k1Constants::N - 2, Secp256k1Constants::N) }
+      let(:u) { z * s_inv % Secp256k1Constants::N }
+      let(:v) { signature.r * s_inv % Secp256k1Constants::N }
+      let(:random_target) { (ECC::S256Point::G * u + private_key.point * v).x.num }
+
+      it 'generates a valid signature' do
+        expect(signature.r).to eq random_target
+      end
     end
   end
 end

--- a/spec/ecc/private_key_spec.rb
+++ b/spec/ecc/private_key_spec.rb
@@ -4,9 +4,9 @@ require 'ecc/signature'
 RSpec.describe ECC::PrivateKey do
 
   describe 'sign' do
-    let(:secret) { rand(ECC::N) }
+    let(:secret) { rand(Secp256k1Constants::N) }
     let(:private_key) { described_class.new(secret) }
-    let(:z) { rand(ECC::N) }
+    let(:z) { rand(Secp256k1Constants::N) }
     let(:signature) { private_key.sign(z) }
 
     it 'generates a valid signature' do

--- a/spec/ecc/s256_field_spec.rb
+++ b/spec/ecc/s256_field_spec.rb
@@ -1,0 +1,19 @@
+require 'ecc/s256_field'
+
+RSpec.describe ECC::S256Field do
+  let(:num) { 637353833 }
+  let(:element) { described_class.new(num)}
+  let(:p_order) { (2**256 - 2**32 - 977) }
+
+  describe 'init' do
+    it 'sets P as prime' do
+      expect(element.prime).to eq p_order
+    end
+  end
+
+  describe '#to_s' do
+    it 'parses s256 field element to expected format' do
+      expect(element.to_s).to eq "0000000000000000000000000000000000000000000000000000000637353833"
+    end
+  end
+end

--- a/spec/ecc/s256_point_spec.rb
+++ b/spec/ecc/s256_point_spec.rb
@@ -2,7 +2,7 @@ require 'ecc/s256_point'
 require 'ecc/s256_field'
 require 'ecc/field_element'
 require 'ecc/signature'
-require 'ecc/constants'
+require 'ecc/secp256k1_constants.rb'
 
 RSpec.describe ECC::S256Point do
 
@@ -18,7 +18,7 @@ RSpec.describe ECC::S256Point do
   end
 
   describe 'order of group' do
-    let(:identity) { described_class.G * ECC::N }
+    let(:identity) { Secp256k1Constants::N * described_class::G }
 
     it 'returns identity point' do
       expect( [identity.x, identity.y]).to eq [nil, nil]
@@ -32,7 +32,7 @@ RSpec.describe ECC::S256Point do
     let(:point) { ECC::S256Point.new(x, y) }
 
     it 'returns public point' do
-      expect(described_class.G * secret).to eq point
+      expect(secret * described_class::G).to eq point
     end
   end
 

--- a/spec/ecc/s256_point_spec.rb
+++ b/spec/ecc/s256_point_spec.rb
@@ -1,0 +1,73 @@
+require 'ecc/s256_point'
+require 'ecc/s256_field'
+require 'ecc/field_element'
+require 'ecc/signature'
+require 'ecc/constants'
+
+RSpec.describe ECC::S256Point do
+
+  describe 'init' do
+    context 'when S256Point is initialized but is not part of the curve' do
+      let(:x) { 0x887387e452b8eacc4acfde10d9aaf7e6d9a0f975aabb10d006e4da568744d06c }
+      let(:y) { 0x61de6d95231cd29026e286df3e6ae4a894a3378e393e93a0f45b666329a0ae34 }
+
+      it 'raises an ArgumentError' do
+        expect { described_class.new(x,y) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe 'order of group' do
+    let(:identity) { described_class.G * ECC::N }
+
+    it 'returns identity point' do
+      expect( [identity.x, identity.y]).to eq [nil, nil]
+    end
+  end
+
+  describe 'secret and generator point solves to public point' do
+    let(:secret) { 7 }
+    let(:x) { 0x5cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc }
+    let(:y) { 0x6aebca40ba255960a3178d6d861a54dba813d0b813fde7b5a5082628087264da }
+    let(:point) { ECC::S256Point.new(x, y) }
+
+    it 'returns public point' do
+      expect(described_class.G * secret).to eq point
+    end
+  end
+
+  describe 'verify' do
+    let(:x) { 0x887387e452b8eacc4acfde10d9aaf7f6d9a0f975aabb10d006e4da568744d06c }
+    let(:y) { 0x61de6d95231cd89026e286df3b6ae4a894a3378e393e93a0f45b666329a0ae34 }
+    let(:point) { ECC::S256Point.new(x, y) }
+
+    let(:r) { 0xac8d1c87e51d0d441be8b3dd5b05c8795b48875dffe00b7ffcfac23010d3a395 }
+    let(:s) { 0x68342ceff8935ededd102dd876ffd6ba72d6a427a3edb13d26eb0781cb423c4 }
+    let(:signature) { ECC::Signature.new(r, s) }
+
+    let(:z) { 0xec208baa0fc1c19f708a9ca96fdeff3ac3f230bb4a7ba4aede4942ad003c0f60 }
+
+    context 'when signature is valid' do
+      it 'returns true' do
+        expect(point.verify(z, signature)).to be true
+      end
+    end
+
+    context 'when signature is not valid' do
+      let(:r_modified) { 0xac8d1c87eeed0d441be8b3dd5b05c8795b48875dffe00b7ffcfac23010d3a395 }
+      let(:signature_modified) { ECC::Signature.new(r_modified, s) }
+
+      it 'returns false' do
+        expect(point.verify(z, signature_modified)).to be false
+      end
+    end
+
+    context 'when message is altered' do
+      let(:z_modified) { 0xec208baa0fc1c194408a9ca96fdeff3ac3f230bb4a7ba4aede4942ad003c0f60 }
+
+      it 'returns false' do
+        expect(point.verify(z_modified, signature)).to be false
+      end
+    end
+  end
+end

--- a/spec/ecc/signature_spec.rb
+++ b/spec/ecc/signature_spec.rb
@@ -1,0 +1,17 @@
+require 'ecc/signature'
+
+RSpec.describe ECC::Signature do
+  let(:r) { 0xac8d1c87e51d0d441be8b3dd5b05c8795b48875dffe00b7ffcfac23010d3a395 }
+  let(:s) { 0x68342ceff8935ededd102dd876ffd6ba72d6a427a3edb13d26eb0781cb423c4 }
+  let(:signature) { described_class.new(r, s) }
+
+  describe 'to_s' do
+    let(:string_format) {
+      "Signature(78047132305074547209667415378684003360790728528333174453334458954808711947157,"\
+      " 2945795152904547855448158643091235482997756069461486099501216307557115896772)"
+      }
+    it 'parses signature to expected format' do
+      expect(signature.to_s).to eq string_format
+    end
+  end
+end


### PR DESCRIPTION
Exercises from Chapter 3  🚀 

Cosas que mejorar:
- Separe el metodo `add_same_points` segun la clase del input. Lo ideal seria que dentro del metodo acomode las operaciones (en el libro se hace asi, pero no pude replicarlo en ruby)
- El producto escalar solo funciona con el argumento a la derecha, `point * scalar`  . Seria bueno que funcionara de forma `scalar * point` tambien

Pendiente
- conversion de int a bytes de variables `z` y `secret` en `PrivateKey#deterministic_k` no entrega size de 32