### PR TITLE
Feat/chapter4 serialization

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,517 @@
+require:
+  - rubocop-rspec
+  - rubocop-rails
+  - rubocop-performance
+AllCops:
+  Exclude:
+  - "vendor/**/*"
+  - "db/**/*"
+  - "bin/**/*"
+  TargetRubyVersion: 2.7
+Rails:
+  Enabled: true
+Performance:
+  Enabled: true
+Layout/ParameterAlignment:
+  Description: Align the parameters of a method call if they span more than one line.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-double-indent
+  Enabled: true
+  EnforcedStyle: with_fixed_indentation
+  SupportedStyles:
+  - with_first_parameter
+  - with_fixed_indentation
+Metrics/BlockLength:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Description: Checks style of children classes and modules.
+  Enabled: false
+  EnforcedStyle: nested
+  SupportedStyles:
+  - nested
+  - compact
+Style/CommentAnnotation:
+  Description: Checks formatting of special comments (TODO, FIXME, OPTIMIZE, HACK,
+    REVIEW).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#annotate-keywords
+  Enabled: false
+  Keywords:
+  - TODO
+  - FIXME
+  - OPTIMIZE
+  - HACK
+  - REVIEW
+Naming/FileName:
+  Description: Use snake_case for source file names.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
+  Enabled: false
+  Exclude: []
+Style/FormatString:
+  Description: Enforce the use of Kernel#sprintf, Kernel#format or String#%.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#sprintf
+  Enabled: false
+  EnforcedStyle: format
+  SupportedStyles:
+  - format
+  - sprintf
+  - percent
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/GlobalVars:
+  Description: Do not introduce global variables.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#instance-vars
+  Enabled: false
+  AllowedVariables: []
+Style/GuardClause:
+  Description: Check for conditionals that can be replaced with guard clauses
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
+  Enabled: false
+  MinBodyLength: 1
+Style/IfUnlessModifier:
+  Description: Favor modifier if/unless usage when you have a single-line body.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
+  Enabled: false
+Style/LambdaCall:
+  Description: Use lambda.call(...) instead of lambda.(...).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#proc-call
+  Enabled: false
+  EnforcedStyle: call
+  SupportedStyles:
+  - call
+  - braces
+Style/Next:
+  Description: Use `next` to skip iteration instead of a condition at the end.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
+  Enabled: false
+  EnforcedStyle: skip_modifier_ifs
+  MinBodyLength: 3
+  SupportedStyles:
+  - skip_modifier_ifs
+  - always
+Layout/MultilineOperationIndentation:
+  Description: Checks indentation of binary operations that span more than one line.
+  Enabled: true
+  EnforcedStyle: indented
+  SupportedStyles:
+  - aligned
+  - indented
+Style/MutableConstant:
+  Description: Do not assign mutable objects to constants.
+  Enabled: false
+Style/NumericLiterals:
+  Description: Add underscores to large numeric literals to improve their readability.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics
+  Enabled: false
+  MinDigits: 5
+Style/PercentLiteralDelimiters:
+  Description: Use `%`-literal delimiters consistently
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-literal-braces
+  Enabled: false
+  PreferredDelimiters:
+    "%": "()"
+    "%i": "()"
+    "%q": "()"
+    "%Q": "()"
+    "%r": "{}"
+    "%s": "()"
+    "%w": "()"
+    "%W": "()"
+    "%x": "()"
+Naming/PredicateName:
+  Description: Check the names of predicate methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark
+  Enabled: true
+  NamePrefix:
+  - is_
+  - has_
+  - have_
+  ForbiddenPrefixes:
+  - is_
+Style/RaiseArgs:
+  Description: Checks the arguments passed to raise/fail.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#exception-class-messages
+  Enabled: false
+  EnforcedStyle: exploded
+  SupportedStyles:
+  - compact
+  - exploded
+Style/SignalException:
+  Description: Checks for proper usage of fail and raise.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#fail-method
+  Enabled: false
+  EnforcedStyle: semantic
+  SupportedStyles:
+  - only_raise
+  - only_fail
+  - semantic
+Style/SingleLineMethods:
+  Description: Avoid single-line methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-single-line-methods
+  Enabled: false
+  AllowIfMethodIsEmpty: true
+Style/StringLiterals:
+  Description: Checks if uses of quotes match the configured preference.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
+  Enabled: false
+  EnforcedStyle: double_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes
+Style/TrailingCommaInArguments:
+  Description: Checks for trailing comma in argument lists.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
+  Enabled: true
+Style/TrailingCommaInArrayLiteral:
+  Description: Checks for trailing comma in array and hash literals.
+  StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#no-trailing-array-commas
+  Enabled: true
+Style/TrailingCommaInHashLiteral:
+  Description: Checks for trailing comma in array and hash literals.
+  StyleGuide: https://github.com/rubocop-hq/ruby-style-guide#no-trailing-array-commas
+  Enabled: true
+Style/TrivialAccessors:
+  Description: Prefer attr_* methods to trivial readers/writers.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#attr_family
+  Enabled: false
+  ExactNameMatch: false
+  AllowPredicates: false
+  AllowDSLWriters: false
+  AllowedMethods:
+  - to_ary
+  - to_a
+  - to_c
+  - to_enum
+  - to_h
+  - to_hash
+  - to_i
+  - to_int
+  - to_io
+  - to_open
+  - to_path
+  - to_proc
+  - to_r
+  - to_regexp
+  - to_str
+  - to_s
+  - to_sym
+Style/WhileUntilModifier:
+  Description: Favor modifier while/until usage when you have a single-line body.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier
+  Enabled: false
+Style/WordArray:
+  Description: Use %w or %W for arrays of words.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-w
+  Enabled: false
+  MinSize: 0
+  WordRegex: !ruby/regexp /\A[\p{Word}]+\z/
+Style/ExponentialNotation:
+  Enabled: true
+Style/HashEachMethods:
+  Description: Use Hash#each_key and Hash#each_value.
+  Enabled: true
+Style/HashTransformKeys:
+  Description: Prefer `transform_keys` over `each_with_object` and `map`.
+  Enabled: true
+Style/HashTransformValues:
+  Description: Prefer `transform_values` over `each_with_object` and `map`.
+  Enabled: true
+Metrics/AbcSize:
+  Description: A calculated magnitude based on number of assignments, branches, and
+    conditions.
+  Enabled: true
+  Max: 25
+Metrics/BlockNesting:
+  Description: Avoid excessive block nesting
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count
+  Enabled: true
+  Max: 3
+Metrics/ClassLength:
+  Description: Avoid classes longer than 100 lines of code.
+  Enabled: false
+  CountComments: false
+  Max: 100
+Metrics/MethodLength:
+  Description: Avoid methods longer than 15 lines of code.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
+  Enabled: true
+  CountComments: true
+  Max: 15
+  Exclude:
+  - "spec/**/*"
+Metrics/ParameterLists:
+  Description: Avoid long parameter lists.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#too-many-params
+  Enabled: false
+  Max: 5
+  CountKeywordArgs: true
+Lint/AssignmentInCondition:
+  Description: Don't use assignment in conditions.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition
+  Enabled: false
+  AllowSafeAssignment: true
+Layout/LineLength:
+  Description: Limit lines to 100 characters.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#100-character-limits
+  Enabled: true
+  Max: 100
+  AllowURI: true
+  URISchemes:
+  - http
+  - https
+Layout/EndAlignment:
+  Description: Align ends correctly.
+  Enabled: true
+  EnforcedStyleAlignWith: keyword
+  SupportedStylesAlignWith:
+  - keyword
+  - variable
+Layout/DefEndAlignment:
+  Description: Align ends corresponding to defs correctly.
+  Enabled: true
+  EnforcedStyleAlignWith: start_of_line
+  SupportedStylesAlignWith:
+  - start_of_line
+  - def
+Layout/SpaceAroundMethodCallOperator:
+  Description: Checks method call operators to not have spaces around them.
+  Enabled: true
+Style/SymbolArray:
+  Description: Use %i or %I for arrays of symbols.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-i
+  Enabled: false
+Layout/ExtraSpacing:
+  Description: Do not use unnecessary spacing.
+  Enabled: false
+Naming/AccessorMethodName:
+  Description: Check the naming of accessor methods for get_/set_.
+  Enabled: false
+Style/Alias:
+  Description: Use alias_method instead of alias.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#alias-method
+  Enabled: false
+Style/ArrayJoin:
+  Description: Use Array#join instead of Array#*.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#array-join
+  Enabled: false
+Style/AsciiComments:
+  Description: Use only ascii symbols in comments.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#english-comments
+  Enabled: false
+Naming/AsciiIdentifiers:
+  Description: Use only ascii symbols in identifiers.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#english-identifiers
+  Enabled: false
+Style/Attr:
+  Description: Checks for uses of Module#attr.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#attr
+  Enabled: false
+Style/BlockComments:
+  Description: Do not use block comments.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-block-comments
+  Enabled: false
+Style/CaseEquality:
+  Description: Avoid explicit use of the case equality operator(===).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-case-equality
+  Enabled: false
+Style/CharacterLiteral:
+  Description: Checks for uses of character literals.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-character-literals
+  Enabled: false
+Style/ClassVars:
+  Description: Avoid the use of class variables.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-class-vars
+  Enabled: false
+Style/ColonMethodCall:
+  Description: 'Do not use :: for method call.'
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#double-colons
+  Enabled: false
+Style/PreferredHashMethods:
+  Description: Checks for use of deprecated Hash methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-key
+  Enabled: false
+Style/Documentation:
+  Description: Document classes and non-namespace modules.
+  Enabled: false
+Style/DoubleNegation:
+  Description: Checks for uses of double negation (!!).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-bang-bang
+  Enabled: false
+Style/EachWithObject:
+  Description: Prefer `each_with_object` over `inject` or `reduce`.
+  Enabled: false
+Style/EmptyElse:
+  Description: Avoid empty else-clauses.
+  Enabled: true
+Style/EmptyLiteral:
+  Description: Prefer literals to Array.new/Hash.new/String.new.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#literal-array-hash
+  Enabled: false
+Layout/EndOfLine:
+  Description: Use Unix-style line endings.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#crlf
+  Enabled: true
+Style/EvenOdd:
+  Description: Favor the use of Fixnum#even? && Fixnum#odd?
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#predicate-methods
+  Enabled: false
+Lint/FlipFlop:
+  Description: Checks for flip flops
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-flip-flops
+  Enabled: false
+Style/IfWithSemicolon:
+  Description: Do not use if x; .... Use the ternary operator instead.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs
+  Enabled: false
+Style/Lambda:
+  Description: Use the new lambda literal syntax for single-line blocks.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#lambda-multi-line
+  Enabled: false
+Style/LineEndConcatenation:
+  Description: Use \ instead of + or << to concatenate two string literals at line
+    end.
+  Enabled: false
+Style/ModuleFunction:
+  Description: Checks for usage of `extend self` in modules.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#module-function
+  Enabled: false
+Style/MultilineBlockChain:
+  Description: Avoid multi-line chains of blocks.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#single-line-blocks
+  Enabled: false
+Layout/MultilineBlockLayout:
+  Description: Ensures newlines after multiline block do statements.
+  Enabled: false
+Style/NegatedIf:
+  Description: Favor unless over if for negative conditions (or control flow or).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#unless-for-negatives
+  Enabled: false
+Style/NegatedWhile:
+  Description: Favor until over while for negative conditions.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#until-for-negatives
+  Enabled: false
+Style/NilComparison:
+  Description: Prefer x.nil? to x == nil.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#predicate-methods
+  Enabled: false
+Style/OneLineConditional:
+  Description: Favor the ternary operator(?:) over if/then/else/end constructs.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#ternary-operator
+  Enabled: false
+Naming/BinaryOperatorParameterName:
+  Description: When defining binary operators, name the argument other.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#other-arg
+  Enabled: false
+Style/PerlBackrefs:
+  Description: Avoid Perl-style regex back references.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers
+  Enabled: false
+Style/Proc:
+  Description: Use proc instead of Proc.new.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#proc
+  Enabled: false
+Style/SelfAssignment:
+  Description: Checks for places where self-assignment shorthand should have been
+    used.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#self-assignment
+  Enabled: false
+Layout/SpaceBeforeFirstArg:
+  Description: Put a space between a method name and the first argument in a method
+    call without parentheses.
+  Enabled: true
+Layout/SpaceAroundOperators:
+  Description: Use spaces around operators.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
+  Enabled: true
+Layout/SpaceInsideParens:
+  Description: No spaces after ( or before ).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-spaces-braces
+  Enabled: true
+Style/SpecialGlobalVars:
+  Description: Avoid Perl-style global variables.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms
+  Enabled: false
+Style/VariableInterpolation:
+  Description: Don't interpolate global, instance and class variables directly in
+    strings.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#curlies-interpolate
+  Enabled: false
+Style/WhenThen:
+  Description: Use when x then ... for one-line cases.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#one-line-cases
+  Enabled: false
+Lint/AmbiguousOperator:
+  Description: Checks for ambiguous operators in the first argument of a method invocation
+    without parentheses.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#parens-as-args
+  Enabled: false
+Lint/AmbiguousRegexpLiteral:
+  Description: Checks for ambiguous regexp literals in the first argument of a method
+    invocation without parenthesis.
+  Enabled: false
+Layout/BlockAlignment:
+  Description: Align block ends correctly.
+  Enabled: true
+Layout/ConditionPosition:
+  Description: Checks for condition placed in a confusing position relative to the
+    keyword.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#same-line-condition
+  Enabled: false
+Lint/DeprecatedClassMethods:
+  Description: Check for deprecated class method calls.
+  Enabled: false
+Lint/ElseLayout:
+  Description: Check for odd code arrangement in an else block.
+  Enabled: false
+Lint/SuppressedException:
+  Description: Don't suppress exception.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
+  Enabled: false
+Lint/LiteralAsCondition:
+  Description: Checks of literals used in conditions.
+  Enabled: false
+Lint/LiteralInInterpolation:
+  Description: Checks for literals used in interpolation.
+  Enabled: false
+Lint/Loop:
+  Description: Use Kernel#loop with break rather than begin/end/until or begin/end/while
+    for post-loop tests.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#loop-with-break
+  Enabled: false
+Lint/ParenthesesAsGroupedExpression:
+  Description: Checks for method calls with a space before the opening parenthesis.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#parens-no-spaces
+  Enabled: false
+Lint/RequireParentheses:
+  Description: Use parentheses in the method call to avoid confusion about precedence.
+  Enabled: false
+Lint/UnderscorePrefixedVariableName:
+  Description: Do not use prefix `_` for a variable that is used.
+  Enabled: false
+Lint/Void:
+  Description: Possible use of operator/literal/variable in void context.
+  Enabled: false
+Lint/RaiseException:
+  Description: Checks for `raise` or `fail` statements which are raising `Exception` class.
+  Enabled: true
+Lint/StructNewOverride:
+  Description: Disallow overriding the `Struct` built-in methods via `Struct.new`.
+  Enabled: true
+Rails/Delegate:
+  Description: Prefer delegate method for delegations.
+  Enabled: false
+Performance/RedundantBlockCall:
+  Description: Use `yield` instead of `block.call`.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#proccall-vs-yield-code
+  Enabled: false
+RSpec/MultipleExpectations:
+  Max: 5
+RSpec/NestedGroups:
+  Max: 5
+RSpec/ExampleLength:
+  Max: 10
+RSpec/LetSetup:
+  Enabled: false
+RSpec/ExpectChange:
+  Enabled: true
+  EnforcedStyle: block
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false

--- a/lib/ecc/field_element.rb
+++ b/lib/ecc/field_element.rb
@@ -42,13 +42,11 @@ module ECC
     def *(other)
       if other.is_a?(FieldElement)
         check_prime_for('multiply', other)
-
         num = (@num * other.num) % @prime
-        self.class.new(num, @prime)
       else
         num = (@num * other) % @prime
-        self.class.new(num, @prime)
       end
+      self.class.new(num, @prime)
     end
 
     def **(exponent)

--- a/lib/ecc/point.rb
+++ b/lib/ecc/point.rb
@@ -1,10 +1,10 @@
-require_relative 'field_element.rb'
+require_relative 'field_element'
 
 module ECC
   class Point
     attr_reader :x, :y, :a, :b
 
-    def initialize(x,y,a,b)
+    def initialize(x, y, a, b)
       @x = x
       @y = y
       @a = a
@@ -14,7 +14,7 @@ module ECC
       if y**2 != x**3 + a * x + b
         raise ArgumentError.new "(#{x},#{y}) is not on the curve"
       end
-   end
+    end
 
     def ==(other)
       return false unless other
@@ -33,13 +33,12 @@ module ECC
     end
 
     def +(other)
-      if @a != other.a || @b != other.b
-        raise TypeError.new "Points #{self}, #{other} are not in the same curve"
-      end
+      check_curve_for(other)
 
       return other if @x.nil?
       return self if other.x.nil?
       return identity if @x == other.x && @y != other.y
+
       self != other ? add_different_points(other) : add_same_points
     end
 
@@ -61,24 +60,39 @@ module ECC
     end
 
     def add_different_points(other)
-      slope = @x.respond_to?(:to_f) ? (other.y - @y).to_f / (other.x - @x) :
-                                      (other.y - @y) / (other.x - @x)
+      slope = if @x.respond_to?(:to_f)
+                (other.y - @y).to_f / (other.x - @x)
+              else
+                (other.y - @y) / (other.x - @x)
+              end
+
       x = slope**2 - @x - other.x
       y = slope * (@x - x) - @y
       self.class.new(x, y, @a, @b)
     end
 
     def add_same_points
-      return identity if @y == 0 * self.x
-      slope = @x.respond_to?(:to_f) ? ((3 * @x ** 2 + @a).to_f / (2 * @y)) :
-                                      ((3 * @x ** 2 + @a) / (2 * @y))
-      x = slope ** 2 - 2 * @x
+      return identity if @y == 0 * x
+
+      slope = if @x.respond_to?(:to_f)
+                (3 * @x**2 + @a).to_f / (2 * @y)
+              else
+                (3 * @x**2 + @a) / (2 * @y)
+              end
+
+      x = slope**2 - 2 * @x
       y = slope * (@x - x) - @y
       self.class.new(x, y, @a, @b)
     end
 
     def identity
       @identity ||= self.class.new(nil, nil, @a, @b)
+    end
+
+    def check_curve_for(other)
+      if @a != other.a || @b != other.b
+        raise TypeError.new "Points #{self}, #{other} are not in the same curve"
+      end
     end
   end
 end

--- a/lib/ecc/private_key.rb
+++ b/lib/ecc/private_key.rb
@@ -1,7 +1,7 @@
-require_relative 's256_point.rb'
-require_relative 'signature.rb'
-require_relative 'secp256k1_constants.rb'
-require_relative '../helper.rb'
+require_relative 's256_point'
+require_relative 'signature'
+require_relative 'secp256k1_constants'
+require_relative '../helper'
 require 'openssl'
 
 module ECC
@@ -21,7 +21,7 @@ module ECC
       k = deterministic_k(z)
       r = (k * ECC::S256Point::G).x.num
       k_inv = k.pow(Secp256k1Constants::N - 2, Secp256k1Constants::N)
-      s = (z + r * @secret ) * k_inv % Secp256k1Constants::N
+      s = (z + r * @secret) * k_inv % Secp256k1Constants::N
 
       s = Secp256k1Constants::N - s if s > Secp256k1Constants::N / 2
 

--- a/lib/ecc/private_key.rb
+++ b/lib/ecc/private_key.rb
@@ -1,11 +1,12 @@
 require_relative 's256_point'
 require_relative 'signature'
 require_relative 'secp256k1_constants'
-require_relative '../helper'
+require_relative '../encoding_helper'
 require 'openssl'
 
 module ECC
   class PrivateKey
+    include EncodingHelper
     attr_reader :point
 
     def initialize(secret)
@@ -28,32 +29,39 @@ module ECC
       ECC::Signature.new(r, s)
     end
 
+    def wif(compressed: true, testnet: false)
+      secret_bytes = to_bytes(@secret, 32, 'big')
+      prefix = to_bytes(testnet ? 0xef : 0x80, 1, 'big')
+      suffix = compressed ? "\x01" : ""
+      encode_base58_checksum("#{prefix}#{secret_bytes}#{suffix}")
+    end
+
+    private
+
     def deterministic_k(z)
-      k = "\x00".b * 32
-      v = "\x01".b * 32
-      if z > Secp256k1Constants::N
-        z -= Secp256k1Constants::N
-      end
+      z -= Secp256k1Constants::N if z > Secp256k1Constants::N
 
-      z_bytes = [z].pack("N").rjust(32, "\x00".b)
-      secret_bytes = [@secret].pack("N").rjust(32, "\x00".b)
+      z_bytes = to_bytes(z, 32, 'big')
+      secret_bytes = to_bytes(@secret, 32, 'big')
 
-      message_1 = v + "\x00".b + secret_bytes + z_bytes
-      k = OpenSSL::HMAC.digest("SHA256", k, message_1)
-      v = OpenSSL::HMAC.digest("SHA256", k, v)
+      k = sha256_hmac("\x00" * 32, "#{"\x01" * 32}\x00#{secret_bytes}#{z_bytes}")
+      v = sha256_hmac(k, "\x01" * 32)
 
-      message_2 = v + "\x01".b + secret_bytes + z_bytes
-      k = OpenSSL::HMAC.digest("SHA256", k, message_2)
-      v = OpenSSL::HMAC.digest("SHA256", k, v)
+      k = sha256_hmac(k, "#{v}\x01#{secret_bytes}#{z_bytes}")
+      v = sha256_hmac(k, v)
 
-      while true
-        v = OpenSSL::HMAC.digest("SHA256", k, v)
-        candidate = v.unpack("N").first
+      loop do
+        v = sha256_hmac(k, v)
+        candidate = from_bytes(v, 'big')
         return candidate if candidate >= 1 && candidate < Secp256k1Constants::N
 
-        k = OpenSSL::HMAC.digest("SHA256", k, v + "\x00".b)
-        v = OpenSSL::HMAC.digest("SHA256", k, v)
+        k = sha256_hmac(k, "#{v}\x00")
+        v = sha256_hmac(k, v)
       end
+    end
+
+    def sha256_hmac(key, data)
+      OpenSSL::HMAC.digest("SHA256", key, data)
     end
   end
 end

--- a/lib/ecc/s256_field.rb
+++ b/lib/ecc/s256_field.rb
@@ -10,5 +10,9 @@ module ECC
     def to_s
       @num.to_s.rjust(64, '0')
     end
+
+    def sqrt
+      self**((@prime + 1) / 4)
+    end
   end
 end

--- a/lib/ecc/s256_field.rb
+++ b/lib/ecc/s256_field.rb
@@ -1,9 +1,8 @@
-require_relative 'field_element.rb'
-require_relative 'secp256k1_constants.rb'
+require_relative 'field_element'
+require_relative 'secp256k1_constants'
 
 module ECC
   class S256Field < FieldElement
-
     def initialize(num, prime = Secp256k1Constants::P)
       super(num, prime)
     end

--- a/lib/ecc/s256_point.rb
+++ b/lib/ecc/s256_point.rb
@@ -1,9 +1,14 @@
 require_relative 's256_field'
 require_relative 'point'
 require_relative 'secp256k1_constants'
+require_relative '../encoding_helper'
+require_relative '../hash_helper'
 
 module ECC
   class S256Point < Point
+    include EncodingHelper
+    extend EncodingHelper
+
     def initialize(x, y, _a = 0, _b = 7)
       a = S256Field.new(Secp256k1Constants::A)
       b = S256Field.new(Secp256k1Constants::B)
@@ -29,10 +34,6 @@ module ECC
       super(coef)
     end
 
-    def self.G
-      S256Point.new(Secp256k1Constants::G_X, Secp256k1Constants::G_Y)
-    end
-
     def verify(z, signature)
       s_inv = signature.s.pow(Secp256k1Constants::N - 2, Secp256k1Constants::N)
       u = z * s_inv % Secp256k1Constants::N
@@ -40,5 +41,47 @@ module ECC
       random_target = (u * self.class::G + v * self).x.num
       random_target == signature.r
     end
+
+    def sec(compressed: true)
+      if compressed
+        prefix = y.num.even? ? to_bytes(2, 1, 'big') : to_bytes(3, 1, 'big')
+        return prefix + to_bytes(x.num, 32, 'big')
+      end
+
+      to_bytes(4, 1, 'big') + to_bytes(x.num, 32, 'big') + to_bytes(y.num, 32, 'big')
+    end
+
+    def hash160(compressed: true)
+      HashHelper.hash160(sec(compressed: compressed))
+    end
+
+    def address(compressed: true, testnet: false)
+      prefix = testnet ? "\x6f" : "\x00"
+      encode_base58_checksum(prefix + hash160(compressed: compressed))
+    end
+
+    def self.parse(sec_bin)
+      return parse_uncompressed(sec_bin) if sec_bin[0] == "\x04"
+
+      x = S256Field.new(from_bytes(sec_bin[1..], 'big'))
+      alpha = x**3 + S256Field.new(Secp256k1Constants::B)
+      beta = alpha.sqrt
+      if beta.num.even?
+        even_beta = beta
+        odd_beta = S256Field.new(Secp256k1Constants::P - beta.num)
+      else
+        even_beta = S256Field.new(Secp256k1Constants::P - beta.num)
+        odd_beta = beta
+      end
+      sec_bin[0] == "\x02" ? new(x, even_beta) : new(x, odd_beta)
+    end
+
+    def self.parse_uncompressed(sec_bin)
+      x = from_bytes(sec_bin.slice(1, 32), 'big')
+      y = from_bytes(sec_bin.slice(33, 32), 'big')
+      new(x, y)
+    end
+
+    private_class_method :parse_uncompressed
   end
 end

--- a/lib/ecc/s256_point.rb
+++ b/lib/ecc/s256_point.rb
@@ -1,21 +1,19 @@
-require_relative 's256_field.rb'
-require_relative 'point.rb'
-require_relative 'secp256k1_constants.rb'
+require_relative 's256_field'
+require_relative 'point'
+require_relative 'secp256k1_constants'
 
 module ECC
   class S256Point < Point
-
-    def initialize(x, y, a = 0, b = 7)
+    def initialize(x, y, _a = 0, _b = 7)
       a = S256Field.new(Secp256k1Constants::A)
       b = S256Field.new(Secp256k1Constants::B)
 
       if x.is_a?(Integer)
         x = S256Field.new(x)
         y = S256Field.new(y)
-        super(x, y, a, b)
-      else
-        super(x, y, a, b)
       end
+
+      super(x, y, a, b)
     end
 
     G = S256Point.new(Secp256k1Constants::G_X, Secp256k1Constants::G_Y)

--- a/lib/ecc/signature.rb
+++ b/lib/ecc/signature.rb
@@ -1,5 +1,8 @@
+require_relative '../encoding_helper'
 module ECC
   class Signature
+    include EncodingHelper
+    extend EncodingHelper
     attr_reader :r, :s
 
     def initialize(r, s)
@@ -7,8 +10,60 @@ module ECC
       @s = s
     end
 
+    def ==(other)
+      @r == other.r && @s == other.s
+    end
+
     def to_s
       "Signature(#{@r}, #{s})"
     end
+
+    def der
+      rbin = formatted_to_sec(@r)
+      result = "\x02#{to_bytes(rbin.length, rbin.length.digits(256).length, 'big')}#{rbin}"
+      sbin = formatted_to_sec(@s)
+      result += "\x02#{to_bytes(sbin.length, sbin.length.digits(256).length, 'big')}#{sbin}"
+      "\x30#{to_bytes(result.length, result.length.digits(256).length, 'big')}#{result}"
+    end
+
+    def self.parse(signature_bin)
+      signature_length = signature_bin.length
+      raise SignatureError.new "First byte must be \x30" if signature_bin.slice!(0) != "\x30"
+
+      length = from_bytes(signature_bin.slice!(0), 'big')
+      raise SignatureError.new 'Bad signature length' if length + 2 != signature_length
+
+      check_sec_marker(signature_bin.slice!(0))
+
+      signature_bin, r_length, r = get_vals_from_sec_bin(signature_bin)
+      check_sec_marker(signature_bin.slice!(0))
+
+      _, s_length, s = get_vals_from_sec_bin(signature_bin)
+      raise SignatureError.new 'Signature too long' if signature_length != 6 + r_length + s_length
+
+      new(r, s)
+    end
+
+    private
+
+    def formatted_to_sec(elem)
+      bin_elem = to_bytes(elem, 32, 'big')
+      bin_elem = bin_elem.reverse.chomp("\x00").reverse
+      bin_elem[0].unpack1('C') > 128 ? "\x00#{bin_elem}" : bin_elem
+    end
+
+    def self.check_sec_marker(marker)
+      raise SignatureError.new "expected marker to be \x02" if marker != "\x02"
+    end
+
+    def self.get_vals_from_sec_bin(signature_bin)
+      r_length = from_bytes(signature_bin.slice!(0), 'big')
+      r = from_bytes(signature_bin.slice!(0, r_length), 'big')
+      [signature_bin, r_length, r]
+    end
+
+    private_class_method :check_sec_marker, :get_vals_from_sec_bin
   end
+
+  class SignatureError < StandardError; end
 end

--- a/lib/ecc/signature.rb
+++ b/lib/ecc/signature.rb
@@ -1,5 +1,4 @@
 module ECC
-
   class Signature
     attr_reader :r, :s
 

--- a/lib/encoding_helper.rb
+++ b/lib/encoding_helper.rb
@@ -1,0 +1,68 @@
+require 'hash_helper'
+
+module EncodingHelper
+  BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+  def from_bytes(bytes, endianness)
+    bytes = bytes.unpack('C*')
+    bytes.reverse! if endianness == 'big'
+    bytes.map.with_index { |byte, index| byte * 256**index }.sum
+  end
+
+  def to_bytes(integer, bytes, endianness)
+    byte_array = [0] * bytes
+    integer.digits(256).each_with_index do |byte, index|
+      byte_array[index] = byte
+    end
+    byte_array.reverse! if endianness == 'big'
+    byte_array.pack('c*')
+  end
+
+  def encode_base58(bytes)
+    zero_prefix_length = 0
+    bytes.each_char { |char| char == "\x00" ? zero_prefix_length += 1 : break }
+
+    num = from_bytes(bytes, 'big')
+    prefix = '1' * zero_prefix_length
+    prefix + num.digits(58).reverse.map { |d| BASE58_ALPHABET[d] }.join
+  end
+
+  def encode_base58_checksum(bytes)
+    encode_base58(bytes + HashHelper.hash256(bytes).slice(0, 4))
+  end
+
+  def decode_base58(string)
+    zero_prefix_length = 0
+    string.each_char { |char| char == '1' ? zero_prefix_length += 1 : break }
+    num = base58_to_num(string)
+    prefix = "\x00" * zero_prefix_length
+    combined = prefix + to_bytes(num, num.digits(256).count, 'big')
+    checksum = combined.slice(-4, 4)
+    message = combined.slice(0, combined.length - 4)
+    computed_hash = HashHelper.hash256(message).slice(0, 4)
+    if computed_hash != checksum
+      raise  StandardError.new "bad address: #{checksum} #{computed_hash}"
+    end
+
+    message
+  end
+
+  def little_endian_to_int(bytes)
+    from_bytes(bytes, 'little')
+  end
+
+  def int_to_little_endian(int, length)
+    to_bytes(int, length, 'little')
+  end
+
+  private
+
+  def base58_to_num(base58_string)
+    num = 0
+    base58_string.each_char do |char|
+      num *= 58
+      num += BASE58_ALPHABET.index char
+    end
+    num
+  end
+end

--- a/lib/hash_helper.rb
+++ b/lib/hash_helper.rb
@@ -1,0 +1,13 @@
+require 'digest'
+
+module HashHelper
+  def self.hash160(string)
+    first_round = Digest::SHA256.digest(string)
+    Digest::RMD160.digest(first_round)
+  end
+
+  def self.hash256(string)
+    first_round = Digest::SHA256.digest(string)
+    Digest::SHA256.digest(first_round)
+  end
+end

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -1,6 +1,0 @@
-require 'digest'
-
-def hash256(s)
-  first_round = Digest::SHA256.digest(s)
-  Digest::SHA256.hexdigest(first_round).to_i(16)
-end

--- a/spec/ecc/ecc_spec.rb
+++ b/spec/ecc/ecc_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ECC do
   let(:b) { ECC::FieldElement.new(7, prime) }
   let(:x1) { ECC::FieldElement.new(192, prime) }
   let(:y1) { ECC::FieldElement.new(105, prime) }
-  let(:point_1) { ECC::Point.new(x1, y1, a, b) }
+  let(:point1) { ECC::Point.new(x1, y1, a, b) }
 
   describe 'point init over field elements' do
     context 'when point is not part of the curve' do
@@ -24,30 +24,30 @@ RSpec.describe ECC do
     context 'when points are over same finite field' do
       let(:x2) { ECC::FieldElement.new(17, prime) }
       let(:y2) { ECC::FieldElement.new(56, prime) }
-      let(:point_2) { ECC::Point.new(x2, y2, a, b) }
+      let(:point2) { ECC::Point.new(x2, y2, a, b) }
 
       let(:x_sol) { ECC::FieldElement.new(170, prime) }
       let(:y_sol) { ECC::FieldElement.new(142, prime) }
       let(:solution) { ECC::Point.new(x_sol, y_sol, a, b) }
 
       it 'returns the point sum' do
-        expect(point_1 + point_2).to eq solution
+        expect(point1 + point2).to eq solution
       end
     end
   end
 
   describe 'scalar multiplication of point over finite elements' do
-      let(:scalar) { 2 }
-      let(:x) { ECC::FieldElement.new(49, prime) }
-      let(:y) { ECC::FieldElement.new(71, prime) }
-      let(:solution) { ECC::Point.new(x, y, a, b) }
+    let(:scalar) { 2 }
+    let(:x) { ECC::FieldElement.new(49, prime) }
+    let(:y) { ECC::FieldElement.new(71, prime) }
+    let(:solution) { ECC::Point.new(x, y, a, b) }
 
-      it 'returns the point scalar product (scalar on the right side)' do
-        expect(point_1 * scalar ).to eq solution
-      end
+    it 'returns the point scalar product (scalar on the right side)' do
+      expect(point1 * scalar ).to eq solution
+    end
 
-      it 'returns the point scalar product (scalar on the left side)' do
-        expect(scalar * point_1 ).to eq solution
-      end
+    it 'returns the point scalar product (scalar on the left side)' do
+      expect(scalar * point1 ).to eq solution
+    end
   end
 end

--- a/spec/ecc/private_key_spec.rb
+++ b/spec/ecc/private_key_spec.rb
@@ -2,28 +2,48 @@ require 'ecc/private_key'
 require 'ecc/signature'
 
 RSpec.describe ECC::PrivateKey do
-
-  describe 'sign' do
+  describe '#sign' do
     let(:secret) { rand(Secp256k1Constants::N) }
     let(:private_key) { described_class.new(secret) }
     let(:z) { rand(Secp256k1Constants::N) }
     let(:signature) { private_key.sign(z) }
 
-    context 'validation using point method verify' do
-      it 'generates a valid signature' do
-        expect(private_key.point.verify(z, signature)).to be true
-      end
+    it 'generates a valid point verifiable signature' do
+      expect(private_key.point.verify(z, signature)).to be true
     end
 
-    context 'validation using analytical calculations' do
-      let(:s_inv) { signature.s.pow(Secp256k1Constants::N - 2, Secp256k1Constants::N) }
-      let(:u) { z * s_inv % Secp256k1Constants::N }
-      let(:v) { signature.r * s_inv % Secp256k1Constants::N }
-      let(:random_target) { (ECC::S256Point::G * u + private_key.point * v).x.num }
+    it 'generates a valid signature' do
+      s_inv = signature.s.pow(Secp256k1Constants::N - 2, Secp256k1Constants::N)
+      u = z * s_inv % Secp256k1Constants::N
+      v = signature.r * s_inv % Secp256k1Constants::N
+      random_target = (ECC::S256Point::G * u + private_key.point * v).x.num
+      expect(signature.r).to eq random_target
+    end
+  end
 
-      it 'generates a valid signature' do
-        expect(signature.r).to eq random_target
-      end
+  describe '#wif' do
+    it 'returns the proper compressed wif private key for testnet' do
+      secret = 0x1cca23de92fd1862fb5b76e5f4f50eb082165e5191e116c18ed1a6b24be6a53f
+      wif = 'cNYfWuhDpbNM1JWc3c6JTrtrFVxU4AGhUKgw5f93NP2QaBqmxKkg'
+      expect(described_class.new(secret).wif(compressed: true, testnet: true)).to eq wif
+    end
+
+    it 'returns the proper uncompressed wif private key for testnet' do
+      secret = 2**256 - 2**201
+      wif = '93XfLeifX7Jx7n7ELGMAf1SUR6f9kgQs8Xke8WStMwUtrDucMzn'
+      expect(described_class.new(secret).wif(compressed: false, testnet: true)).to eq wif
+    end
+
+    it 'returns the proper compressed wif private key for mainnet' do
+      secret = 2**256 - 2**199
+      wif = 'L5oLkpV3aqBJ4BgssVAsax1iRa77G5CVYnv9adQ6Z87te7TyUdSC'
+      expect(described_class.new(secret).wif(compressed: true, testnet: false)).to eq wif
+    end
+
+    it 'returns the proper uncompressed wif private key for mainnet' do
+      secret = 0x0dba685b4511dbd3d368e5c4358a1277de9486447af7b3604a69b8d9d8b7889d
+      wif = '5HvLFPDVgFZRK9cd4C5jcWki5Skz6fmKqi1GQJf5ZoMofid2Dty'
+      expect(described_class.new(secret).wif(compressed: false, testnet: false)).to eq wif
     end
   end
 end

--- a/spec/ecc/s256_field_spec.rb
+++ b/spec/ecc/s256_field_spec.rb
@@ -16,4 +16,11 @@ RSpec.describe ECC::S256Field do
       expect(element.to_s).to eq "0000000000000000000000000000000000000000000000000000000637353833"
     end
   end
+
+  describe '#sqrt' do
+    it 'computes one of the roots over the field' do
+      root = element.sqrt
+      expect(root * root).to eq element
+    end
+  end
 end

--- a/spec/ecc/s256_field_spec.rb
+++ b/spec/ecc/s256_field_spec.rb
@@ -2,7 +2,7 @@ require 'ecc/s256_field'
 
 RSpec.describe ECC::S256Field do
   let(:num) { 637353833 }
-  let(:element) { described_class.new(num)}
+  let(:element) { described_class.new(num) }
   let(:p_order) { (2**256 - 2**32 - 977) }
 
   describe 'init' do

--- a/spec/ecc/s256_point_spec.rb
+++ b/spec/ecc/s256_point_spec.rb
@@ -2,17 +2,16 @@ require 'ecc/s256_point'
 require 'ecc/s256_field'
 require 'ecc/field_element'
 require 'ecc/signature'
-require 'ecc/secp256k1_constants.rb'
+require 'ecc/secp256k1_constants'
 
 RSpec.describe ECC::S256Point do
-
   describe 'init' do
     context 'when S256Point is initialized but is not part of the curve' do
       let(:x) { 0x887387e452b8eacc4acfde10d9aaf7e6d9a0f975aabb10d006e4da568744d06c }
       let(:y) { 0x61de6d95231cd29026e286df3e6ae4a894a3378e393e93a0f45b666329a0ae34 }
 
       it 'raises an ArgumentError' do
-        expect { described_class.new(x,y) }.to raise_error(ArgumentError)
+        expect { described_class.new(x, y) }.to raise_error(ArgumentError)
       end
     end
   end
@@ -21,7 +20,7 @@ RSpec.describe ECC::S256Point do
     let(:identity) { Secp256k1Constants::N * described_class::G }
 
     it 'returns identity point' do
-      expect( [identity.x, identity.y]).to eq [nil, nil]
+      expect([identity.x, identity.y]).to eq [nil, nil]
     end
   end
 
@@ -29,7 +28,7 @@ RSpec.describe ECC::S256Point do
     let(:secret) { 7 }
     let(:x) { 0x5cbdf0646e5db4eaa398f365f2ea7a0e3d419b7e0330e39ce92bddedcac4f9bc }
     let(:y) { 0x6aebca40ba255960a3178d6d861a54dba813d0b813fde7b5a5082628087264da }
-    let(:point) { ECC::S256Point.new(x, y) }
+    let(:point) { described_class.new(x, y) }
 
     it 'returns public point' do
       expect(secret * described_class::G).to eq point
@@ -39,7 +38,7 @@ RSpec.describe ECC::S256Point do
   describe 'verify' do
     let(:x) { 0x887387e452b8eacc4acfde10d9aaf7f6d9a0f975aabb10d006e4da568744d06c }
     let(:y) { 0x61de6d95231cd89026e286df3b6ae4a894a3378e393e93a0f45b666329a0ae34 }
-    let(:point) { ECC::S256Point.new(x, y) }
+    let(:point) { described_class.new(x, y) }
 
     let(:r) { 0xac8d1c87e51d0d441be8b3dd5b05c8795b48875dffe00b7ffcfac23010d3a395 }
     let(:s) { 0x68342ceff8935ededd102dd876ffd6ba72d6a427a3edb13d26eb0781cb423c4 }

--- a/spec/ecc/signature_spec.rb
+++ b/spec/ecc/signature_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ECC::Signature do
   let(:s) { 0x68342ceff8935ededd102dd876ffd6ba72d6a427a3edb13d26eb0781cb423c4 }
   let(:signature) { described_class.new(r, s) }
 
-  describe 'to_s' do
+  describe '#to_s' do
     let(:string_format) do
       "Signature(78047132305074547209667415378684003360790728528333174453334458954808711947157,"\
       " 2945795152904547855448158643091235482997756069461486099501216307557115896772)"
@@ -13,6 +13,52 @@ RSpec.describe ECC::Signature do
 
     it 'parses signature to expected format' do
       expect(signature.to_s).to eq string_format
+    end
+  end
+
+  describe '#==' do
+    it 'returns true on equal r and s signatures' do
+      r = 0x37206a0610995c58074999cb9767b87af4c4978db68c06e8e6e81d282047a7c6
+      s = 0x8ca63759c1157ebeaec0d03cecca119fc9a75bf8e6d0fa65c841c8e2738cdaec
+      sig1 = described_class.new(r, s)
+      sig2 = described_class.new(r, s)
+      expect(sig1 == sig2).to be true
+    end
+
+    it 'returns false on different r' do
+      r = 0x37206a0610995c58074999cb9767b87af4c4978db68c06e8e6e81d282047a7c6
+      s = 0x8ca63759c1157ebeaec0d03cecca119fc9a75bf8e6d0fa65c841c8e2738cdaec
+      sig1 = described_class.new(r, s)
+      sig2 = described_class.new(r + 1, s)
+      expect(sig1 == sig2).to be false
+    end
+
+    it 'returns false on different s' do
+      r = 0x37206a0610995c58074999cb9767b87af4c4978db68c06e8e6e81d282047a7c6
+      s = 0x8ca63759c1157ebeaec0d03cecca119fc9a75bf8e6d0fa65c841c8e2738cdaec
+      sig1 = described_class.new(r, s)
+      sig2 = described_class.new(r, s + 1)
+      expect(sig1 == sig2).to be false
+    end
+  end
+
+  describe '#der' do
+    it 'serializes signature in DER format' do
+      hex_der_sig = "3045022037206a0610995c58074999cb9767b87af4c4978db68c06e8e6e81d282047a7c602210"\
+                    "08ca63759c1157ebeaec0d03cecca119fc9a75bf8e6d0fa65c841c8e2738cdaec"
+      r = 0x37206a0610995c58074999cb9767b87af4c4978db68c06e8e6e81d282047a7c6
+      s = 0x8ca63759c1157ebeaec0d03cecca119fc9a75bf8e6d0fa65c841c8e2738cdaec
+      sig = described_class.new(r, s)
+      expect(sig.der.unpack1('H*')).to eq hex_der_sig
+    end
+  end
+
+  describe '#self.parse' do
+    it 'returns the proper Signature object' do
+      r = 0x37206a0610995c58074999cb9767b87af4c4978db68c06e8e6e81d282047a7c6
+      s = 0x8ca63759c1157ebeaec0d03cecca119fc9a75bf8e6d0fa65c841c8e2738cdaec
+      sig = described_class.new(r, s)
+      expect(described_class.parse(sig.der)).to eq sig
     end
   end
 end

--- a/spec/ecc/signature_spec.rb
+++ b/spec/ecc/signature_spec.rb
@@ -6,10 +6,11 @@ RSpec.describe ECC::Signature do
   let(:signature) { described_class.new(r, s) }
 
   describe 'to_s' do
-    let(:string_format) {
+    let(:string_format) do
       "Signature(78047132305074547209667415378684003360790728528333174453334458954808711947157,"\
       " 2945795152904547855448158643091235482997756069461486099501216307557115896772)"
-      }
+    end
+
     it 'parses signature to expected format' do
       expect(signature.to_s).to eq string_format
     end

--- a/spec/encoding_helper_spec.rb
+++ b/spec/encoding_helper_spec.rb
@@ -1,0 +1,75 @@
+require 'encoding_helper'
+
+RSpec.describe EncodingHelper do
+  let(:described_module) { Object.new.extend described_class }
+
+  describe '#to_bytes' do
+    it 'computes the little endian bytes' do
+      bytes_solution = ",\x0f\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"\
+                       "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+      bytes = described_module.to_bytes(69420, 32, 'little')
+      expect(bytes).to eq bytes_solution
+    end
+
+    it 'computes the big endian bytes' do
+      bytes_solution = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"\
+                       "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x0f,"
+      bytes = described_module.to_bytes(69420, 32, 'big')
+      expect(bytes).to eq bytes_solution
+    end
+  end
+
+  describe '#from_bytes' do
+    it 'computes the int from byte array in big endian' do
+      bytes = "\x00\x00\x01\xff\x00\x00\x01\xff"
+      expect(described_module.from_bytes(bytes, 'big')).to eq 2194728288767
+    end
+
+    it 'computes the int from byte array in little endian' do
+      bytes = "\x00\x00\x01\xff\x00\x00\x01\xff"
+      expect(described_module.from_bytes(bytes, 'little')).to eq 18374967958926589952
+    end
+  end
+
+  describe '#encode_base58' do
+    it 'properly encodes to base 58' do
+      base58 = 'vfUSmu3zfEoexnsWT1rSwgbStVv'
+      expect(described_module.encode_base58('Bitcoin Guild rocks!')).to eq base58
+    end
+  end
+
+  describe '#encode_base58_checksum' do
+    it 'encodes in base58 the bytes with checksum' do
+      base58 = '749vn7Y5mhjURoGG3gk25WxY3SxkE21fN'
+      expect(described_module.encode_base58_checksum('Bitcoin Guild rocks!')).to eq base58
+    end
+  end
+
+  describe '#decode_base58' do
+    it 'decodes a base58 with checksum message' do
+      message = 'Bitcoin Guild rocks!'
+      checksum_encoded = described_module.encode_base58_checksum(message)
+      expect(described_module.decode_base58(checksum_encoded)).to eq message
+    end
+
+    it 'raises an error when checksum does not match' do
+      message = 'Bitcoin Guild rocks!'
+      checksum_encoded = described_module.encode_base58_checksum(message)
+      checksum_encoded[-1] = 'X'
+      expect { described_module.decode_base58(checksum_encoded) }.to raise_error StandardError
+    end
+  end
+
+  describe '#little_endian_to_int' do
+    it 'takes byte sequence as a little-endian number' do
+      bytes = '99c3980000000000'.to_i(16).digits(256).reverse.pack('c*')
+      expect(described_module.little_endian_to_int(bytes)).to eq 10011545
+    end
+  end
+
+  describe '#int_to_little_endian' do
+    it 'takes an integer and returns the little-endian byte sequence of length' do
+      expect(described_module.int_to_little_endian(1, 4)).to eq "\x01\x00\x00\x00"
+    end
+  end
+end

--- a/spec/hash_helper_spec.rb
+++ b/spec/hash_helper_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe HashHelper do
+  describe '#hash160' do
+    it 'computes the hash by sha256 followed by ripemd160' do
+      hash = '77bc43ce98ed7de19a42b6f2b8978df300890a2d'
+      expect(described_class.hash160('Bitcoin Guild rocks!').unpack1('H*')).to eq(hash)
+    end
+  end
+
+  describe '#hash256' do
+    it 'computes the hash by two passes of sha256' do
+      hash = 'a63898c9855b802d6db18886928affbc22b928c3ccd683e21d62da8f0af00a42'
+      expect(described_class.hash256('Bitcoin Guild rocks!').unpack1('H*')).to eq(hash)
+    end
+  end
+end


### PR DESCRIPTION
* Arregla varios alegatos de linter, agrega .rubocop y .editorconfig.
* Agrega los métodos de serialización (capítulo 4)
* Implementa métodos `from_bytes` y `to_bytes` para reducir la dificultad de trabajar con bytes (hacerlo más parecido a python)