### PR TITLE
Chapter 08 - p2sh

### DIFF
--- a/lib/address_helper.rb
+++ b/lib/address_helper.rb
@@ -1,0 +1,20 @@
+# encoding: ascii-8bit
+
+require 'encoding_helper'
+
+module AddressHelper
+  include EncodingHelper
+  extend self
+
+  def h160_to_p2pkh_address(h160, testnet: false)
+    prefix = testnet ? "\x6f" : "\x00"
+
+    encode_base58_checksum(prefix + h160)
+  end
+
+  def h160_to_p2sh_address(h160, testnet: false)
+    prefix = testnet ? "\xc4" : "\x05"
+
+    encode_base58_checksum(prefix + h160)
+  end
+end

--- a/lib/bitcoin/op.rb
+++ b/lib/bitcoin/op.rb
@@ -9,9 +9,11 @@ module Bitcoin
     include EncodingHelper
     include ScriptHelper
 
-    def op_0(stack)
-      stack << encode_num(0)
-      true
+    (0..16).each do |num|
+      define_method :"op_#{num}" do |stack|
+        stack << encode_num(num)
+        true
+      end
     end
 
     def op_drop(stack)
@@ -44,7 +46,7 @@ module Bitcoin
       true
     end
 
-    def op_checksig(stack, z)
+    def op_checksig(stack, z) # rubocop:disable Naming/MethodParameterName
       return false if stack.length < 2
 
       sec_pubkey = stack.pop

--- a/lib/bitcoin/tx.rb
+++ b/lib/bitcoin/tx.rb
@@ -70,8 +70,7 @@ module Bitcoin
       end
 
       def serialize
-        result = int_to_little_endian(@amount, 8)
-        result += @script_pubkey.serialize
+        int_to_little_endian(@amount, 8) + @script_pubkey.serialize
       end
 
       attr_accessor :amount, :script_pubkey
@@ -116,35 +115,13 @@ module Bitcoin
       @fee ||= calculate_fee
     end
 
-    def sig_hash(input_index)
-      result = int_to_little_endian version, 4
-      result << encode_varint(ins.size)
-
-      ins.each_with_index do |input, index|
-        if index == input_index
-          result << TxIn.new(
-            input.prev_tx,
-            input.prev_index,
-            input.script_pubkey(testnet: @testnet),
-            input.sequence
-          ).serialize
-        else
-          result << TxIn.new(
-            input.prev_tx,
-            input.prev_index,
-            nil,
-            input.sequence
-          ).serialize
-        end
-      end
-
-      result << encode_varint(outs.size)
-      outs.each do |output|
-        result << output.serialize
-      end
-
+    def sig_hash(input_index, redeem_script = nil)
+      result = int_to_little_endian(version, 4)
+      result << encode_ins(input_index, redeem_script)
+      result << encode_outs
       result << int_to_little_endian(locktime, 4)
       result << int_to_little_endian(SIGHASH_ALL, 4)
+
       hash256 = HashHelper.hash256 result
 
       from_bytes hash256, 'big'
@@ -153,7 +130,15 @@ module Bitcoin
     def verify_input(input_index)
       tx_in = ins[input_index]
       script_pubkey = tx_in.script_pubkey testnet: @testnet
-      z = sig_hash(input_index)
+
+      if script_pubkey.p2sh?
+        cmd = tx_in.script_sig.cmds[-1]
+        raw_redeem = encode_varint(cmd.length) + cmd
+        redeem_script = Script.parse(StringIO.new(raw_redeem))
+      else
+        redeem_script = nil
+      end
+      z = sig_hash(input_index, redeem_script)
       combined = tx_in.script_sig + script_pubkey
       combined.evaluate(z)
     end
@@ -161,7 +146,7 @@ module Bitcoin
     def verify?
       return false if @fee.negative?
 
-      ins.each_with_index  do |input, index|
+      ins.each_with_index do |_, index|
         return false unless verify_input index
       end
 
@@ -179,6 +164,29 @@ module Bitcoin
     end
 
     private
+
+    def encode_ins(input_index, redeem_script)
+      result = encode_varint(ins.size)
+
+      ins.each_with_index do |input, index|
+        script_sig = if index == input_index
+                       redeem_script || input.script_pubkey(testnet: @testnet)
+                     end
+
+        result << TxIn.new(
+          input.prev_tx,
+          input.prev_index,
+          script_sig,
+          input.sequence
+        ).serialize
+      end
+
+      result
+    end
+
+    def encode_outs
+      encode_varint(outs.size) + outs.map(&:serialize).join
+    end
 
     def calculate_fee
       raise 'transaction fetcher not provided' if @tx_fetcher.nil?

--- a/lib/ecc/s256_point.rb
+++ b/lib/ecc/s256_point.rb
@@ -3,7 +3,7 @@ require_relative 'point'
 require_relative 'secp256k1_constants'
 require_relative '../encoding_helper'
 require_relative '../hash_helper'
-
+require_relative '../address_helper'
 module ECC
   class S256Point < Point
     include EncodingHelper
@@ -56,8 +56,10 @@ module ECC
     end
 
     def address(compressed: true, testnet: false)
-      prefix = testnet ? "\x6f" : "\x00"
-      encode_base58_checksum(prefix + hash160(compressed: compressed))
+      AddressHelper.h160_to_p2pkh_address(
+        hash160(compressed: compressed),
+        testnet: testnet
+      )
     end
 
     def self.parse(sec_bin)

--- a/spec/address_helper_spec.rb
+++ b/spec/address_helper_spec.rb
@@ -1,0 +1,49 @@
+require 'address_helper'
+
+RSpec.describe AddressHelper do
+  let(:described_module) { Object.new.extend described_class }
+
+  describe '#h160_to_p2pkh_address' do
+    let(:h160) { ['74d691da1574e6b3c192ecfb52cc8984ee7b6c56'].pack('H*') }
+
+    context 'when testnet is true' do
+      let(:testnet) { true }
+
+      it 'calculates the testnet address' do
+        expect(described_module.h160_to_p2pkh_address(h160, testnet: testnet))
+          .to eq('mrAjisaT4LXL5MzE81sfcDYKU3wqWSvf9q')
+      end
+    end
+
+    context 'when testnet is false' do
+      let(:testnet) { false }
+
+      it 'calculates the mainnet address' do
+        expect(described_module.h160_to_p2pkh_address(h160, testnet: testnet))
+          .to eq('1BenRpVUFK65JFWcQSuHnJKzc4M8ZP8Eqa')
+      end
+    end
+  end
+
+  describe '#h160_to_p2sh_address' do
+    let(:h160) { ['74d691da1574e6b3c192ecfb52cc8984ee7b6c56'].pack('H*') }
+
+    context 'when testnet is true' do
+      let(:testnet) { true }
+
+      it 'calculates the testnet address' do
+        expect(described_module.h160_to_p2sh_address(h160, testnet: testnet))
+          .to eq('2N3u1R6uwQfuobCqbCgBkpsgBxvr1tZpe7B')
+      end
+    end
+
+    context 'when testnet is false' do
+      let(:testnet) { false }
+
+      it 'calculates the mainnet address' do
+        expect(described_module.h160_to_p2sh_address(h160, testnet: testnet))
+          .to eq('3CLoMMyuoDQTPRD3XYZtCvgvkadrAdvdXh')
+      end
+    end
+  end
+end

--- a/spec/bitcoin/op_spec.rb
+++ b/spec/bitcoin/op_spec.rb
@@ -204,6 +204,141 @@ RSpec.describe Bitcoin::Op do
     end
   end
 
+  describe '#op_checkmultisig' do
+    context 'when the stack is empty' do
+      let(:stack) { [] }
+      let(:z) { 1 }
+
+      it 'returns false' do
+        expect(described_module.op_checkmultisig(stack, z)).to be false
+      end
+    end
+
+    context 'when n does not match the number of pubkeys' do
+      let(:z) { 1 }
+      let(:stack) do [
+        ['1111'].pack("H*"),
+        ['2222'].pack("H*"),
+        "\x05"
+      ]
+      end
+
+      it 'returns false' do
+        expect(described_module.op_checkmultisig(stack, z)).to be false
+      end
+    end
+
+    context 'when m does not match the number of signatures' do
+      let(:z) { 1 }
+      let(:stack) do [
+        "\x00",
+        ['3333'].pack("H*"),
+        "\x03",
+        ['2222'].pack("H*"),
+        ['1111'].pack("H*"),
+        "\x02"
+      ]
+      end
+
+      it 'returns false' do
+        expect(described_module.op_checkmultisig(stack, z)).to be false
+      end
+    end
+
+    context 'when there is no points for verfiying a signature' do
+      let(:z) { 1 }
+      let(:stack) do [
+        "\x00",
+        ['3333'].pack("H*"),
+        "\x01",
+        "\x00"
+      ]
+      end
+
+      it 'returns false' do
+        expect(described_module.op_checkmultisig(stack, z)).to be false
+      end
+    end
+
+    context 'when m of the signatures are valid for m distinct public keys' do
+      raw_sign1 = ['1111'].pack("H*")
+      raw_sign2 = ['2222'].pack("H*")
+      raw_point1 = ['3333'].pack("H*")
+      raw_point2 = ['4444'].pack("H*")
+      raw_point3 = ['5555'].pack("H*")
+
+      let(:z) { 1 }
+      let(:sign1) { instance_double(ECC::Signature) }
+      let(:sign2) { instance_double(ECC::Signature) }
+      let(:point1) { instance_double(ECC::S256Point) }
+      let(:point2) { instance_double(ECC::S256Point) }
+      let(:point3) { instance_double(ECC::S256Point) }
+
+      before do
+        allow(point1).to receive(:verify).with(z, sign1).and_return(true)
+        allow(point2).to receive(:verify).with(z, sign2).and_return(true)
+
+        allow(point1).to receive(:verify).with(z, sign2).and_return(false)
+        allow(point2).to receive(:verify).with(z, sign1).and_return(false)
+        allow(point3).to receive(:verify).with(z, sign1).and_return(false)
+        allow(point3).to receive(:verify).with(z, sign2).and_return(false)
+      end
+
+      context 'when the signatures are not in the correct order' do
+        before do
+          allow(ECC::Signature).to receive(:parse).and_return(sign2, sign1)
+          allow(ECC::S256Point).to receive(:parse).and_return(point1, point2, point3)
+        end
+
+        let(:stack) do
+          [
+            "\x00",
+            raw_sign1,
+            raw_sign2,
+            "\x02",
+            raw_point3,
+            raw_point2,
+            raw_point1,
+            "\x03"
+          ]
+        end
+
+        it 'returns false' do
+          expect(described_module.op_checkmultisig(stack, z)).to be false
+        end
+      end
+
+      context 'when the signatures are in the correct order' do
+        before do
+          allow(ECC::Signature).to receive(:parse).and_return(sign1, sign2)
+          allow(ECC::S256Point).to receive(:parse).and_return(point1, point2, point3)
+        end
+
+        let(:stack) do
+          [
+            "\x00",
+            raw_sign2,
+            raw_sign1,
+            "\x02",
+            raw_point3,
+            raw_point2,
+            raw_point1,
+            "\x03"
+          ]
+        end
+
+        it 'returns true' do
+          expect(described_module.op_checkmultisig(stack, z)).to be true
+        end
+
+        it 'pushes a 1 into the stack' do
+          described_module.op_checkmultisig(stack, z)
+          expect(stack).to eq(["\x01"])
+        end
+      end
+    end
+  end
+
   # rubocop:disable RSpec/EmptyLineAfterExampleGroup
   # rubocop:disable Style/BlockDelimiters
   xdescribe '#op_pushdata1' do it 'performs op_pushdata1 correctly' end
@@ -260,7 +395,6 @@ RSpec.describe Bitcoin::Op do
   xdescribe '#op_sha256' do it 'performs op_sha256 correctly' end
   xdescribe '#op_codeseparator' do it 'performs op_codeseparator correctly' end
   xdescribe '#op_checksigverify' do it 'performs op_checksigverify correctly' end
-  xdescribe '#op_checkmultisig' do it 'performs op_checkmultisig correctly' end
   xdescribe '#op_checkmultisigverify' do it 'performs op_checkmultisigverify correctly' end
   xdescribe '#op_nop1' do it 'performs op_nop1 correctly' end
   xdescribe '#op_checklocktimeverify' do it 'performs op_checklocktimeverify correctly' end

--- a/spec/bitcoin/op_spec.rb
+++ b/spec/bitcoin/op_spec.rb
@@ -3,12 +3,15 @@ require 'bitcoin/op'
 require 'ecc/s256_point'
 require 'ecc/signature'
 require 'hash_helper'
+require 'encoding_helper'
 
 RSpec.describe Bitcoin::Op do
+  include EncodingHelper
+
   let(:described_module) { Object.new.extend described_class }
 
   describe '#op_0' do
-    it 'pushes a 0 (empty string) into the stack' do
+    it 'pushes an empty string into the stack' do
       stack = []
 
       described_module.op_0(stack)
@@ -16,20 +19,13 @@ RSpec.describe Bitcoin::Op do
     end
   end
 
-  describe '#op_verify' do
-    context 'when the top element of the stack is an empty string' do
-      it 'returns false' do
-        stack = [1, '']
+  (1..16).each do |num|
+    describe "#op_#{num}" do
+      it "pushes a #{num} into the stack" do
+        stack = []
 
-        expect(described_module.op_verify(stack)).to be false
-      end
-    end
-
-    context 'when the top element of the stack is a nonzero string' do
-      it 'returns true' do
-        stack = [1, ['11'].pack("H*")]
-
-        expect(described_module.op_verify(stack)).to be true
+        described_module.send(:"op_#{num}", stack)
+        expect(stack).to eq([to_bytes(num, 1, 'little')])
       end
     end
   end
@@ -72,6 +68,24 @@ RSpec.describe Bitcoin::Op do
         described_module.op_equal(stack)
 
         expect(stack).to eq([""])
+      end
+    end
+  end
+
+  describe '#op_verify' do
+    context 'when the top element of the stack is an empty string' do
+      it 'returns false' do
+        stack = [1, '']
+
+        expect(described_module.op_verify(stack)).to be false
+      end
+    end
+
+    context 'when the top element of the stack is a nonzero string' do
+      it 'returns true' do
+        stack = [1, ['11'].pack("H*")]
+
+        expect(described_module.op_verify(stack)).to be true
       end
     end
   end
@@ -196,22 +210,6 @@ RSpec.describe Bitcoin::Op do
   xdescribe '#op_pushdata2' do it 'performs op_pushdata2 correctly' end
   xdescribe '#op_pushdata4' do it 'performs op_pushdata4 correctly' end
   xdescribe '#op_1negate' do it 'performs op_1negate correctly' end
-  xdescribe '#op_1' do it 'performs op_1 correctly' end
-  xdescribe '#op_2' do it 'performs op_2 correctly' end
-  xdescribe '#op_3' do it 'performs op_3 correctly' end
-  xdescribe '#op_4' do it 'performs op_4 correctly' end
-  xdescribe '#op_5' do it 'performs op_5 correctly' end
-  xdescribe '#op_6' do it 'performs op_6 correctly' end
-  xdescribe '#op_7' do it 'performs op_7 correctly' end
-  xdescribe '#op_8' do it 'performs op_8 correctly' end
-  xdescribe '#op_9' do it 'performs op_9 correctly' end
-  xdescribe '#op_10' do it 'performs op_10 correctly' end
-  xdescribe '#op_11' do it 'performs op_11 correctly' end
-  xdescribe '#op_12' do it 'performs op_12 correctly' end
-  xdescribe '#op_13' do it 'performs op_13 correctly' end
-  xdescribe '#op_14' do it 'performs op_14 correctly' end
-  xdescribe '#op_15' do it 'performs op_15 correctly' end
-  xdescribe '#op_16' do it 'performs op_16 correctly' end
   xdescribe '#op_nop' do it 'performs op_nop correctly' end
   xdescribe '#op_if' do it 'performs op_if correctly' end
   xdescribe '#op_notif' do it 'performs op_notif correctly' end

--- a/spec/bitcoin/tx_spec.rb
+++ b/spec/bitcoin/tx_spec.rb
@@ -122,6 +122,16 @@ a9143c82d7df364eb6c75be8c80df2b3eda8db57397088ac46430600"
     it 'verifies unlocking script unlocks the script' do
       expect(tx.verify_input(0)).to be true
     end
+
+    context 'when the script pubkey is p2sh' do
+      let(:raw_tx) do
+        resolve_tx '46df1a9484d0a81d03ce0ee543ab6e1a23ed06175c104a178268fad381216c2b'
+      end
+
+      it 'verifies unlocking script unlocks the script' do
+        expect(tx.verify_input(0)).to be true
+      end
+    end
   end
 
   describe '#sign_input' do


### PR DESCRIPTION
Capítulo 8 del libro _Programming Bitcoin_ de Jimmy Song

### En este PR:
- Se agregan algunas funciones de opcodes:
  - `op_n`, con `n` desde 0 a 16
  - `op_checkmultisig`
- Se agrega soporte para ejecutar el patrón p2sh en la clase `Script`
- Se agregan algunos encoders necesarios para p2sh
- Se modifica la verificación de inputs de transacciones (clase `Tx`), para permitir verificar con p2sh. 