### PR TITLE
refactor(spec/ bitcoin ecc): improve minor rspec styling

### DIFF
--- a/spec/bitcoin/block_spec.rb
+++ b/spec/bitcoin/block_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Bitcoin::Block do
     )
   end
 
-  describe '#self.parse' do
+  describe '.parse' do
     def parse(*args)
       described_class.parse(StringIO.new(*args))
     end
@@ -52,21 +52,21 @@ RSpec.describe Bitcoin::Block do
     end
   end
 
-  describe '#self.target_to_bits' do
+  describe '.target_to_bits' do
     it 'returns a target integer back into bits' do
       expect(described_class.target_to_bits(0x13ce9000000000000000000000000000000000000000000))
         .to eq from_hex_to_bytes('e93c0118')
     end
   end
 
-  describe '#self.bits_to_target' do
+  describe '.bits_to_target' do
     it 'computes the target for the given bits' do
       expect(described_class.bits_to_target(block_header.bits))
         .to eq 0x13ce9000000000000000000000000000000000000000000
     end
   end
 
-  describe '#self.calculate_new_bits' do
+  describe '.calculate_new_bits' do
     it 'computes the new bits 2016-block time differential and the previous bits' do
       expect(described_class.calculate_new_bits(from_hex_to_bytes('54d80118'), 302400))
         .to eq from_hex_to_bytes('00157617')
@@ -85,37 +85,37 @@ RSpec.describe Bitcoin::Block do
 
   describe '#bip9?' do
     context 'with bip9 block' do
-      it { expect(block_header.bip9?).to eq true }
+      it { expect(block_header.bip9?).to be true }
     end
 
     context 'with non bip9 block' do
       before { block_header.version = 0x01000000 }
 
-      it { expect(block_header.bip9?).to eq false }
+      it { expect(block_header.bip9?).to be false }
     end
   end
 
   describe '#bip91?' do
     context 'with non bip91 block' do
-      it { expect(block_header.bip91?).to eq false }
+      it { expect(block_header.bip91?).to be false }
     end
 
     context 'with bip91 block' do
       before { block_header.version = 0x01000010 }
 
-      it { expect(block_header.bip91?).to eq true }
+      it { expect(block_header.bip91?).to be true }
     end
   end
 
   describe '#bip141?' do
     context 'with bip141 block' do
-      it { expect(block_header.bip141?).to eq true }
+      it { expect(block_header.bip141?).to be true }
     end
 
     context 'with non bip141 block' do
       before { block_header.version = 0x01000000 }
 
-      it { expect(block_header.bip141?).to eq false }
+      it { expect(block_header.bip141?).to be false }
     end
   end
 
@@ -129,13 +129,13 @@ RSpec.describe Bitcoin::Block do
 
   describe '#pow_valid?' do
     context 'with valid PoW' do
-      it { expect(block_header.pow_valid?).to eq true }
+      it { expect(block_header.pow_valid?).to be true }
     end
 
     context 'with invalid PoW' do
       before { block_header.nonce = from_hex_to_bytes('00000000') }
 
-      it { expect(block_header.pow_valid?).to eq false }
+      it { expect(block_header.pow_valid?).to be false }
     end
   end
 end

--- a/spec/ecc/s256_point_spec.rb
+++ b/spec/ecc/s256_point_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe ECC::S256Point do
     end
   end
 
-  describe '#self.parse' do
+  describe '.parse' do
     it 'returns a Point object from a uncompressed SEC binary' do
       point = ECC::PrivateKey.new(69420).point
       sec_bytes = point.sec(compressed: false)

--- a/spec/ecc/signature_spec.rb
+++ b/spec/ecc/signature_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ECC::Signature do
     end
   end
 
-  describe '#self.parse' do
+  describe '.parse' do
     it 'returns the proper Signature object' do
       r = 0x37206a0610995c58074999cb9767b87af4c4978db68c06e8e6e81d282047a7c6
       s = 0x8ca63759c1157ebeaec0d03cecca119fc9a75bf8e6d0fa65c841c8e2738cdaec


### PR DESCRIPTION
La convención es que los métodos de clase se describen como '.method' y los de instancia como '#method'.

Para comparar con booleanos es preferible usar `be` `true`/`false` en vez de `eq` `true`/`false`