### PR TITLE
Feat/chapter 11 simplified payment verification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 # gem "rails"
 
-gem "pry", groups: [:development]
-gem "rspec", "~> 3.11", groups: [:development, :test]
+gem "pry", :groups => [:development]
+gem 'pry-byebug', :groups => [:development]
+gem "rspec", "~> 3.11", :groups => [:development, :test]
 gem "timecop", "~> 0.9.5", groups: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    byebug (11.1.3)
     coderay (1.1.3)
     diff-lcs (1.5.0)
     method_source (1.0.0)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -29,8 +33,9 @@ PLATFORMS
 
 DEPENDENCIES
   pry
+  pry-byebug
   rspec (~> 3.11)
   timecop (~> 0.9.5)
 
 BUNDLED WITH
-   2.3.16
+   2.3.20

--- a/lib/bitcoin/merkle_block.rb
+++ b/lib/bitcoin/merkle_block.rb
@@ -1,0 +1,55 @@
+require_relative '../bitcoin_data_io'
+require_relative '../encoding_helper'
+require_relative '../merkle_tree'
+
+module Bitcoin
+  class MerkleBlock
+    include EncodingHelper
+    extend EncodingHelper
+
+    def initialize(version, prev_block, merkle_root, timestamp, bits, nonce,
+      total_tx, tx_hashes, flags)
+
+      @version = version
+      @prev_block = prev_block
+      @merkle_root = merkle_root
+      @timestamp = timestamp
+      @bits = bits
+      @nonce = nonce
+      @total_tx = total_tx
+      @tx_hashes = tx_hashes
+      @flags = flags
+    end
+
+    attr_accessor :version, :prev_block, :merkle_root, :timestamp, :bits, :nonce,
+                  :total_tx, :tx_hashes, :flags
+
+    def self.parse(io)
+      io = BitcoinDataIO(io)
+
+      version = little_endian_to_int(io.read(4))
+      prev_block = io.read_le(32)
+      merkle_root = io.read_le(32)
+      timestamp = little_endian_to_int(io.read(4))
+      bits = io.read(4)
+      nonce = io.read(4)
+      total_tx = little_endian_to_int(io.read(4))
+      num_hashes = io.read_varint
+      tx_hashes = []
+      num_hashes.times { tx_hashes << io.read_le(32) }
+      num_flags = io.read_varint
+      flags = io.read_le(num_flags)
+
+      new(version, prev_block, merkle_root, timestamp, bits, nonce, total_tx, tx_hashes, flags)
+    end
+
+    def valid?
+      flag_bits = bytes_to_bit_field(@flags.reverse)
+      hashes = @tx_hashes.map(&:reverse)
+      tree = MerkleTree.new(@total_tx)
+      tree.populate_tree(flag_bits, hashes)
+
+      tree.root.reverse == @merkle_root
+    end
+  end
+end

--- a/lib/encoding_helper.rb
+++ b/lib/encoding_helper.rb
@@ -28,6 +28,17 @@ module EncodingHelper
     byte_array.pack('c*')
   end
 
+  def bytes_to_bit_field(bytes)
+    bit_field = []
+    bytes.each_byte do |byte|
+      8.times do
+        bit_field << (byte & 1)
+        byte >>= 1
+      end
+    end
+    bit_field
+  end
+
   def encode_base58(bytes)
     zero_prefix_length = 0
     bytes.each_char { |char| char == "\x00" ? zero_prefix_length += 1 : break }

--- a/lib/merkle_helper.rb
+++ b/lib/merkle_helper.rb
@@ -1,0 +1,31 @@
+require_relative 'hash_helper'
+
+module MerkleHelper
+  def self.merkle_parent(hash1, hash2)
+    HashHelper.hash256(hash1 + hash2)
+  end
+
+  def self.merkle_parent_level(hashes)
+    raise ArgumentError, "List of hashes can't be of size one" if hashes.size == 1
+
+    if hashes.size.odd?
+      hashes << hashes.last
+    end
+
+    parent_level = []
+
+    (0...hashes.size).step(2) do |i|
+      parent_level << merkle_parent(hashes[i], hashes[i + 1])
+    end
+    parent_level
+  end
+
+  def self.merkle_root(hashes)
+    current_hashes = hashes
+
+    until current_hashes.size == 1
+      current_hashes = merkle_parent_level(current_hashes)
+    end
+    current_hashes.first
+  end
+end

--- a/lib/merkle_tree.rb
+++ b/lib/merkle_tree.rb
@@ -1,0 +1,117 @@
+require_relative './merkle_helper'
+require_relative 'encoding_helper'
+
+class MerkleTree
+  include EncodingHelper
+
+  def initialize(total)
+    @total = total
+    @max_depth = Math.log2(@total).ceil
+    @current_index = 0
+    @current_depth = 0
+
+    build_nodes
+  end
+
+  attr_reader :nodes, :current_index, :current_depth, :total, :max_depth
+
+  def to_s
+    result = []
+    @nodes.each do |level|
+      items = []
+      level.each do |hash|
+        items << (hash.nil? ? "None" : bytes_to_hex(hash)[...8].to_s)
+      end
+      result << items.join(', ')
+    end
+    result.join("\n")
+  end
+
+  def populate_tree(flag_bits, hashes)
+    until root
+      next handle_leaf(flag_bits, hashes) if leaf?
+
+      left_hash = get_left_node
+      next handle_left(flag_bits, hashes) if left_hash.nil?
+      next handle_right(left_hash, get_right_node) if right_exists?
+
+      set_current_node(MerkleHelper.merkle_parent(left_hash, left_hash))
+      up
+    end
+
+    raise "Not all hashes consumed (#{hashes.size})" if hashes.size.positive?
+    raise 'Not all flag bits consumed' unless flag_bits.all?(0)
+  end
+
+  def root
+    @nodes[0][0]
+  end
+
+  private
+
+  def up
+    @current_depth -= 1
+    @current_index /= 2
+  end
+
+  def left
+    @current_depth += 1
+    @current_index *= 2
+  end
+
+  def right
+    @current_depth += 1
+    @current_index = @current_index * 2 + 1
+  end
+
+  def set_current_node(value)
+    @nodes[@current_depth][@current_index] = value
+  end
+
+  def get_current_node
+    @nodes[@current_depth][@current_index]
+  end
+
+  def get_left_node
+    @nodes[@current_depth + 1][@current_index * 2]
+  end
+
+  def get_right_node
+    @nodes[@current_depth + 1][@current_index * 2 + 1]
+  end
+
+  def leaf?
+    @current_depth == @max_depth
+  end
+
+  def right_exists?
+    @nodes[@current_depth + 1].size > @current_index * 2 + 1
+  end
+
+  def handle_left(flag_bits, hashes)
+    return left unless flag_bits.shift.zero?
+
+    set_current_node(hashes.shift)
+    up
+  end
+
+  def handle_right(left_hash, right_hash)
+    return right if right_hash.nil?
+
+    set_current_node(MerkleHelper.merkle_parent(left_hash, right_hash))
+    up
+  end
+
+  def handle_leaf(flag_bits, hashes)
+    flag_bits.shift
+    set_current_node(hashes.shift)
+    up
+  end
+
+  def build_nodes
+    @nodes = (0..@max_depth).map do |depth|
+      num_items = (@total.to_f / 2**(max_depth - depth)).ceil
+      [nil] * num_items
+    end
+  end
+end

--- a/spec/bitcoin/block_spec.rb
+++ b/spec/bitcoin/block_spec.rb
@@ -138,4 +138,48 @@ RSpec.describe Bitcoin::Block do
       it { expect(block_header.pow_valid?).to be false }
     end
   end
+
+  describe '#merkle_root_valid?' do
+    let(:raw_block_header) do
+      from_hex_to_bytes(
+        "00000020fcb19f7895db08cadc9573e7915e3919fb76d59868a51d995201000000000000acbcab8"\
+        "bcc1af95d8d563b77d24c3d19b18f1486383d75a5085c4e86c86beed691cfa85916ca061a00000000"
+      )
+    end
+
+    let(:block_header) { described_class.parse(StringIO.new(*raw_block_header)) }
+    let(:hex_hashes) do
+      [
+        'f54cb69e5dc1bd38ee6901e4ec2007a5030e14bdd60afb4d2f3428c88eea17c1',
+        'c57c2d678da0a7ee8cfa058f1cf49bfcb00ae21eda966640e312b464414731c1',
+        'b027077c94668a84a5d0e72ac0020bae3838cb7f9ee3fa4e81d1eecf6eda91f3',
+        '8131a1b8ec3a815b4800b43dff6c6963c75193c4190ec946b93245a9928a233d',
+        'ae7d63ffcb3ae2bc0681eca0df10dda3ca36dedb9dbf49e33c5fbe33262f0910',
+        '61a14b1bbdcdda8a22e61036839e8b110913832efd4b086948a6a64fd5b3377d',
+        'fc7051c8b536ac87344c5497595d5d2ffdaba471c73fae15fe9228547ea71881',
+        '77386a46e26f69b3cd435aa4faac932027f58d0b7252e62fb6c9c2489887f6df',
+        '59cbc055ccd26a2c4c4df2770382c7fea135c56d9e75d3f758ac465f74c025b8',
+        '7c2bf5687f19785a61be9f46e031ba041c7f93e2b7e9212799d84ba052395195',
+        '08598eebd94c18b0d59ac921e9ba99e2b8ab7d9fccde7d44f2bd4d5e2e726d2e',
+        'f0bb99ef46b029dd6f714e4b12a7d796258c48fee57324ebdc0bbc4700753ab1'
+      ]
+    end
+
+    let(:byte_hashes) { hex_hashes.map { |h| from_hex_to_bytes(h) } }
+
+    context 'with valid tx _hashes' do
+      before { block_header.tx_hashes = byte_hashes }
+
+      it { expect(block_header.merkle_root_valid?).to be true }
+    end
+
+    context 'with invalid tx _hashes' do
+      before do
+        byte_hashes[-1] = from_hex_to_bytes('00000000')
+        block_header.tx_hashes = byte_hashes
+      end
+
+      it { expect(block_header.pow_valid?).to be false }
+    end
+  end
 end

--- a/spec/bitcoin/merkle_block_spec.rb
+++ b/spec/bitcoin/merkle_block_spec.rb
@@ -1,0 +1,108 @@
+require 'bitcoin/merkle_block'
+require 'encoding_helper'
+
+RSpec.describe Bitcoin::MerkleBlock do
+  include EncodingHelper
+
+  let(:raw_merkle_block) do
+    from_hex_to_bytes(
+      "00000020df3b053dc46f162a9b00c7f0d5124e2676d47bbe7c5d0793a500000000000000"\
+      "ef445fef2ed495c275892206ca533e7411907971013ab83e3b47bd0d692d14d4dc7c835b6"\
+      "7d8001ac157e670bf0d00000aba412a0d1480e370173072c9562becffe87aa661c1e4a6db"\
+      "c305d38ec5dc088a7cf92e6458aca7b32edae818f9c2c98c37e06bf72ae0ce80649a38655"\
+      "ee1e27d34d9421d940b16732f24b94023e9d572a7f9ab8023434a4feb532d2adfc8c2c215"\
+      "8785d1bd04eb99df2e86c54bc13e139862897217400def5d72c280222c4cbaee7261831e1"\
+      "550dbb8fa82853e9fe506fc5fda3f7b919d8fe74b6282f92763cef8e625f977af7c8619c3"\
+      "2a369b832bc2d051ecd9c73c51e76370ceabd4f25097c256597fa898d404ed53425de608a"\
+      "c6bfe426f6e2bb457f1c554866eb69dcb8d6bf6f880e9a59b3cd053e6c7060eeacaacf4da"\
+      "c6697dac20e4bd3f38a2ea2543d1ab7953e3430790a9f81e1c67f5b58c825acf46bd02848"\
+      "384eebe9af917274cdfbb1a28a5d58a23a17977def0de10d644258d9c54f886d47d293a41"\
+      "1cb6226103b55635"
+    )
+  end
+
+  let(:hex_hashes) do
+    [
+      'ba412a0d1480e370173072c9562becffe87aa661c1e4a6dbc305d38ec5dc088a',
+      '7cf92e6458aca7b32edae818f9c2c98c37e06bf72ae0ce80649a38655ee1e27d',
+      '34d9421d940b16732f24b94023e9d572a7f9ab8023434a4feb532d2adfc8c2c2',
+      '158785d1bd04eb99df2e86c54bc13e139862897217400def5d72c280222c4cba',
+      'ee7261831e1550dbb8fa82853e9fe506fc5fda3f7b919d8fe74b6282f92763ce',
+      'f8e625f977af7c8619c32a369b832bc2d051ecd9c73c51e76370ceabd4f25097',
+      'c256597fa898d404ed53425de608ac6bfe426f6e2bb457f1c554866eb69dcb8d',
+      '6bf6f880e9a59b3cd053e6c7060eeacaacf4dac6697dac20e4bd3f38a2ea2543',
+      'd1ab7953e3430790a9f81e1c67f5b58c825acf46bd02848384eebe9af917274c',
+      'dfbb1a28a5d58a23a17977def0de10d644258d9c54f886d47d293a411cb62261'
+    ]
+  end
+
+  let(:byte_hashes) { hex_hashes.map { |h| from_hex_to_bytes(h).reverse } }
+
+  let(:merkle_block_solution) do
+    described_class.new(
+      0x20000000,
+      from_hex_to_bytes('df3b053dc46f162a9b00c7f0d5124e2676d47bbe7c5d0793a500000000000000').reverse,
+      from_hex_to_bytes('ef445fef2ed495c275892206ca533e7411907971013ab83e3b47bd0d692d14d4').reverse,
+      little_endian_to_int(from_hex_to_bytes('dc7c835b')),
+      from_hex_to_bytes('67d8001a'),
+      from_hex_to_bytes('c157e670'),
+      little_endian_to_int(from_hex_to_bytes('bf0d0000')),
+      byte_hashes,
+      from_hex_to_bytes('b55635').reverse
+    )
+  end
+
+  describe '.parse' do
+    def parse(*args)
+      described_class.parse(StringIO.new(*args))
+    end
+
+    it 'properly parses the version' do
+      expect(parse(raw_merkle_block).version).to eq merkle_block_solution.version
+    end
+
+    it 'properly parses the previous block' do
+      expect(parse(raw_merkle_block).prev_block).to eq merkle_block_solution.prev_block
+    end
+
+    it 'properly parses the merkle root' do
+      expect(parse(raw_merkle_block).merkle_root).to eq merkle_block_solution.merkle_root
+    end
+
+    it 'properly parses the timestamp' do
+      expect(parse(raw_merkle_block).timestamp).to eq merkle_block_solution.timestamp
+    end
+
+    it 'properly parses the bits' do
+      expect(parse(raw_merkle_block).bits).to eq merkle_block_solution.bits
+    end
+
+    it 'properly parses the nonce' do
+      expect(parse(raw_merkle_block).nonce).to eq merkle_block_solution.nonce
+    end
+
+    it 'properly parses the total_tx' do
+      expect(parse(raw_merkle_block).total_tx).to eq merkle_block_solution.total_tx
+    end
+
+    it 'properly parses the tx_hashes' do
+      expect(parse(raw_merkle_block).tx_hashes).to eq merkle_block_solution.tx_hashes
+    end
+
+    it 'properly parses the flags' do
+      expect(parse(raw_merkle_block).flags).to eq merkle_block_solution.flags
+    end
+  end
+
+  describe '#valid?' do
+    context 'with valid merkle root' do
+      it { expect(merkle_block_solution.valid?).to be true }
+    end
+
+    context 'with invalid merkle root' do
+      before { merkle_block_solution.merkle_root = from_hex_to_bytes('00000000') }
+
+      it { expect(merkle_block_solution.valid?).to be false }
+    end
+  end
+end

--- a/spec/bitcoin_data_io_spec.rb
+++ b/spec/bitcoin_data_io_spec.rb
@@ -1,6 +1,9 @@
+require 'bitcoin_data_io'
 require 'encoding_helper'
 
 RSpec.describe BitcoinDataIO do
+  include EncodingHelper
+
   def io(_hex_data)
     described_class.new(StringIO.new([_hex_data].pack("H*")))
   end
@@ -45,9 +48,5 @@ RSpec.describe BitcoinDataIO do
     it "properly reads the next 8 byte varint" do
       expect(io('ff0807060504030201ff').read_varint).to eq 0x102030405060708
     end
-  end
-
-  def bytes_to_hex(_bytes)
-    _bytes.unpack1("H*")
   end
 end

--- a/spec/encoding_helper_spec.rb
+++ b/spec/encoding_helper_spec.rb
@@ -1,4 +1,5 @@
 # encoding: ascii-8bit
+
 require 'encoding_helper'
 
 RSpec.describe EncodingHelper do
@@ -131,6 +132,15 @@ RSpec.describe EncodingHelper do
   describe '#bytes_to_hex' do
     it 'takes a byte sequence and returns an hex string' do
       expect(described_module.bytes_to_hex("\xA0/")).to eq "a02f"
+    end
+  end
+
+  describe '#bytes_to_bit_field' do
+    let(:bytes) { described_module.from_hex_to_bytes("b55635") }
+
+    it 'takes a string of bytes and returns a bit field array' do
+      expect(described_module.bytes_to_bit_field(bytes))
+        .to eq [1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0]
     end
   end
 end

--- a/spec/merkle_helper_spec.rb
+++ b/spec/merkle_helper_spec.rb
@@ -1,0 +1,104 @@
+require 'merkle_helper'
+require 'encoding_helper'
+
+RSpec.describe MerkleHelper do
+  include EncodingHelper
+
+  describe '#merkle_parent' do
+    let(:hash1) do
+      from_hex_to_bytes('c117ea8ec828342f4dfb0ad6bd140e03a50720ece40169ee38bdc15d9eb64cf5')
+    end
+    let(:hash2) do
+      from_hex_to_bytes('c131474164b412e3406696da1ee20ab0fc9bf41c8f05fa8ceea7a08d672d7cc5')
+    end
+
+    it 'computes the hash of the combined input hashes' do
+      parent_hash = from_hex_to_bytes(
+        '8b30c5ba100f6f2e5ad1e2a742e5020491240f8eb514fe97c713c31718ad7ecd'
+      )
+
+      expect(described_class.merkle_parent(hash1, hash2))
+        .to eq(parent_hash)
+    end
+  end
+
+  # rubocop:disable RSpec/ExampleLength
+  describe '#merkle_parent_level' do
+    let(:hex_hashes) do
+      [
+        'c117ea8ec828342f4dfb0ad6bd140e03a50720ece40169ee38bdc15d9eb64cf5',
+        'c131474164b412e3406696da1ee20ab0fc9bf41c8f05fa8ceea7a08d672d7cc5',
+        'f391da6ecfeed1814efae39e7fcb3838ae0b02c02ae7d0a5848a66947c0727b0',
+        '3d238a92a94532b946c90e19c49351c763696cff3db400485b813aecb8a13181',
+        '10092f2633be5f3ce349bf9ddbde36caa3dd10dfa0ec8106bce23acbff637dae',
+        '7d37b3d54fa6a64869084bfd2e831309118b9e833610e6228adacdbd1b4ba161',
+        '8118a77e542892fe15ae3fc771a4abfd2f5d5d5997544c3487ac36b5c85170fc',
+        'dff6879848c2c9b62fe652720b8df5272093acfaa45a43cdb3696fe2466a3877',
+        'b825c0745f46ac58f7d3759e6dc535a1fec7820377f24d4c2c6ad2cc55c0cb59',
+        '95513952a04bd8992721e9b7e2937f1c04ba31e0469fbe615a78197f68f52b7c',
+        '2e6d722e5e4dbdf2447ddecc9f7dabb8e299bae921c99ad5b0184cd9eb8e5908'
+      ]
+    end
+    let(:byte_hashes) { hex_hashes.map { |h| from_hex_to_bytes(h) } }
+
+    context 'when number of hashes is odd' do
+      it 'returns the merkle parent level' do
+        hex_hashes = [
+          '8b30c5ba100f6f2e5ad1e2a742e5020491240f8eb514fe97c713c31718ad7ecd',
+          '7f4e6f9e224e20fda0ae4c44114237f97cd35aca38d83081c9bfd41feb907800',
+          'ade48f2bbb57318cc79f3a8678febaa827599c509dce5940602e54c7733332e7',
+          '68b3e2ab8182dfd646f13fdf01c335cf32476482d963f5cd94e934e6b3401069',
+          '43e7274e77fbe8e5a42a8fb58f7decdb04d521f319f332d88e6b06f8e6c09e27',
+          '1796cd3ca4fef00236e07b723d3ed88e1ac433acaaa21da64c4b33c946cf3d10'
+        ]
+        bytes_hashes_solution = hex_hashes.map { |h| from_hex_to_bytes(h) }
+
+        expect(described_class.merkle_parent_level(byte_hashes))
+          .to eq(bytes_hashes_solution)
+      end
+    end
+
+    context 'when number of hashes is even' do
+      let(:byte_hashes_even) { byte_hashes.first(4) }
+
+      it 'returns the merkle parent level' do
+        hex_hashes = [
+          '8b30c5ba100f6f2e5ad1e2a742e5020491240f8eb514fe97c713c31718ad7ecd',
+          '7f4e6f9e224e20fda0ae4c44114237f97cd35aca38d83081c9bfd41feb907800'
+        ]
+        bytes_hashes_solution = hex_hashes.map { |h| from_hex_to_bytes(h) }
+
+        expect(described_class.merkle_parent_level(byte_hashes_even))
+          .to eq(bytes_hashes_solution)
+      end
+    end
+  end
+  # rubocop:enable RSpec/ExampleLength
+
+  describe '#merkle_root' do
+    let(:hex_hashes) do
+      [
+        'c117ea8ec828342f4dfb0ad6bd140e03a50720ece40169ee38bdc15d9eb64cf5',
+        'c131474164b412e3406696da1ee20ab0fc9bf41c8f05fa8ceea7a08d672d7cc5',
+        'f391da6ecfeed1814efae39e7fcb3838ae0b02c02ae7d0a5848a66947c0727b0',
+        '3d238a92a94532b946c90e19c49351c763696cff3db400485b813aecb8a13181',
+        '10092f2633be5f3ce349bf9ddbde36caa3dd10dfa0ec8106bce23acbff637dae',
+        '7d37b3d54fa6a64869084bfd2e831309118b9e833610e6228adacdbd1b4ba161',
+        '8118a77e542892fe15ae3fc771a4abfd2f5d5d5997544c3487ac36b5c85170fc',
+        'dff6879848c2c9b62fe652720b8df5272093acfaa45a43cdb3696fe2466a3877',
+        'b825c0745f46ac58f7d3759e6dc535a1fec7820377f24d4c2c6ad2cc55c0cb59',
+        '95513952a04bd8992721e9b7e2937f1c04ba31e0469fbe615a78197f68f52b7c',
+        '2e6d722e5e4dbdf2447ddecc9f7dabb8e299bae921c99ad5b0184cd9eb8e5908',
+        'b13a750047bc0bdceb2473e5fe488c2596d7a7124b4e716fdd29b046ef99bbf0'
+      ]
+    end
+    let(:byte_hashes) { hex_hashes.map { |h| from_hex_to_bytes(h) } }
+
+    it 'computes the merkle root' do
+      hex_root = 'acbcab8bcc1af95d8d563b77d24c3d19b18f1486383d75a5085c4e86c86beed6'
+      bytes = from_hex_to_bytes(hex_root)
+
+      expect(described_class.merkle_root(byte_hashes)).to eq(bytes)
+    end
+  end
+end

--- a/spec/merkle_tree_spec.rb
+++ b/spec/merkle_tree_spec.rb
@@ -1,0 +1,128 @@
+require 'merkle_tree'
+require 'encoding_helper'
+
+RSpec.describe MerkleTree do
+  include EncodingHelper
+
+  describe '#initialize' do
+    context 'when number of leaves is even' do
+      let(:tree) { described_class.new(16) }
+
+      it 'creates tree with correct number of nodes' do
+        expect(tree.nodes.flatten.size).to be(31)
+      end
+
+      it 'creates tree with correct max depth' do
+        expect(tree.max_depth).to be(4)
+      end
+    end
+
+    context 'when number of leaves is odd' do
+      let(:tree) { described_class.new(27) }
+
+      it 'creates tree with correct number of nodes' do
+        expect(tree.nodes.flatten.size).to be(55)
+      end
+    end
+  end
+
+  describe '#to_s' do
+    context 'when tree is empty' do
+      it 'properly represents tree' do
+        tree_string = "None\n"\
+                      "None, None\n"\
+                      "None, None, None, None\n"\
+                      "None, None, None, None, None, None, None, None"
+
+        expect(described_class.new(8).to_s).to eq(tree_string)
+      end
+    end
+
+    context 'when tree is full' do
+      let(:hex_hashes) do
+        [
+          "42f6f52f17620653dcc909e58bb352e0bd4bd1381e2955d19c00959a22122b2e",
+          "94c3af34b9667bf787e1c6a0a009201589755d01d02fe2877cc69b929d2418d4",
+          "959428d7c48113cb9149d0566bde3d46e98cf028053c522b8fa8f735241aa953",
+          "a9f27b99d5d108dede755710d4a1ffa2c74af70b4ca71726fa57d68454e609a2",
+          "62af110031e29de1efcad103b3ad4bec7bdcf6cb9c9f4afdd586981795516577"
+        ]
+      end
+      let(:byte_hashes) { hex_hashes.map { |h| from_hex_to_bytes(h) } }
+      let(:flag_bits) { Array.new(11, 1) }
+      let(:tree) { described_class.new(hex_hashes.size) }
+
+      it 'properly represents tree' do
+        tree.populate_tree(flag_bits, byte_hashes)
+        tree_string = "a8e8bd02\n"\
+                      "e2e5af20, 4e1f780d\n"\
+                      "d7fb8a90, 4e7a9ff0, 610b17d5\n"\
+                      "42f6f52f, 94c3af34, 959428d7, a9f27b99, 62af1100"
+
+        expect(tree.to_s).to eq(tree_string)
+      end
+    end
+  end
+
+  describe '#populate_tree' do
+    context 'when all hashes are given' do
+      let(:hex_hashes) do
+        [
+          "9745f7173ef14ee4155722d1cbf13304339fd00d900b759c6f9d58579b5765fb",
+          "5573c8ede34936c29cdfdfe743f7f5fdfbd4f54ba0705259e62f39917065cb9b",
+          "82a02ecbb6623b4274dfcab82b336dc017a27136e08521091e443e62582e8f05",
+          "507ccae5ed9b340363a0e6d765af148be9cb1c8766ccc922f83e4ae681658308",
+          "a7a4aec28e7162e1e9ef33dfa30f0bc0526e6cf4b11a576f6c5de58593898330",
+          "bb6267664bd833fd9fc82582853ab144fece26b7a8a5bf328f8a059445b59add",
+          "ea6d7ac1ee77fbacee58fc717b990c4fcccf1b19af43103c090f601677fd8836",
+          "457743861de496c429912558a106b810b0507975a49773228aa788df40730d41",
+          "7688029288efc9e9a0011c960a6ed9e5466581abf3e3a6c26ee317461add619a",
+          "b1ae7f15836cb2286cdd4e2c37bf9bb7da0a2846d06867a429f654b2e7f383c9",
+          "9b74f89fa3f93e71ff2c241f32945d877281a6a50a6bf94adac002980aafe5ab",
+          "b3a92b5b255019bdaf754875633c2de9fec2ab03e6b8ce669d07cb5b18804638",
+          "b5c0b915312b9bdaedd2b86aa2d0f8feffc73a2d37668fd9010179261e25e263",
+          "c9d52c5cb1e557b92c84c52e7c4bfbce859408bedffc8a5560fd6e35e10b8800",
+          "c555bc5fc3bc096df0a0c9532f07640bfb76bfe4fc1ace214b8b228a1297a4c2",
+          "f9dbfafc3af3400954975da24eb325e326960a25b87fffe23eef3e7ed2fb610e"
+        ]
+      end
+      let(:byte_hashes) { hex_hashes.map { |h| from_hex_to_bytes(h) } }
+      let(:flag_bits) { Array.new(31, 1) }
+      let(:tree) { described_class.new(hex_hashes.size) }
+
+      it 'properly populates the tree' do
+        tree.populate_tree(flag_bits, byte_hashes)
+        root = '597c4bafe3832b17cbbabe56f878f4fc2ad0f6a402cee7fa851a9cb205f87ed1'
+
+        expect(bytes_to_hex(tree.root)).to eq(root)
+      end
+    end
+
+    context 'when some hashes are given' do
+      let(:hex_hashes) do
+        [
+          'ba412a0d1480e370173072c9562becffe87aa661c1e4a6dbc305d38ec5dc088a',
+          '7cf92e6458aca7b32edae818f9c2c98c37e06bf72ae0ce80649a38655ee1e27d',
+          '34d9421d940b16732f24b94023e9d572a7f9ab8023434a4feb532d2adfc8c2c2',
+          '158785d1bd04eb99df2e86c54bc13e139862897217400def5d72c280222c4cba',
+          'ee7261831e1550dbb8fa82853e9fe506fc5fda3f7b919d8fe74b6282f92763ce',
+          'f8e625f977af7c8619c32a369b832bc2d051ecd9c73c51e76370ceabd4f25097',
+          'c256597fa898d404ed53425de608ac6bfe426f6e2bb457f1c554866eb69dcb8d',
+          '6bf6f880e9a59b3cd053e6c7060eeacaacf4dac6697dac20e4bd3f38a2ea2543',
+          'd1ab7953e3430790a9f81e1c67f5b58c825acf46bd02848384eebe9af917274c',
+          'dfbb1a28a5d58a23a17977def0de10d644258d9c54f886d47d293a411cb62261'
+        ]
+      end
+      let(:byte_hashes) { hex_hashes.map { |h| from_hex_to_bytes(h) } }
+      let(:flag_bits) { [1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0] }
+      let(:tree) { described_class.new(3519) }
+
+      it 'properly populates the tree' do
+        tree.populate_tree(flag_bits, byte_hashes)
+        root_solution = 'ef445fef2ed495c275892206ca533e7411907971013ab83e3b47bd0d692d14d4'
+
+        expect(bytes_to_hex(tree.root)).to eq(root_solution)
+      end
+    end
+  end
+end


### PR DESCRIPTION
En el método `MerkleTree.populate_tree`  rubocop me alega un ` Metrics//PerceivedComplexity`. Desactive el cop, pero tal vez a alguien se le ocurre una forma de simplificarlo (lo hice tal como está en el libro).